### PR TITLE
Add change detection, alerting, RDAP, and watch mode (v1.2.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,16 @@ TYPO_SNIPER_ENABLE_URLSCAN=true
 # Alternative variable names (also supported)
 # URLSCAN_API_KEY=your-urlscan-api-key-here
 # ENABLE_URLSCAN=true
+
+# --- Alerting (optional) -------------------------------------------------
+# Alerts fire only when a scan detects changes since the previous run.
+# TYPO_SNIPER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+# TYPO_SNIPER_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+# TYPO_SNIPER_WEBHOOK_URL=https://your-siem.example.com/ingest
+# TYPO_SNIPER_WEBHOOK_AUTH_HEADER=Authorization: Bearer your-token
+
+# TYPO_SNIPER_SMTP_HOST=smtp.example.com
+# TYPO_SNIPER_SMTP_USERNAME=alerts@example.com
+# TYPO_SNIPER_SMTP_PASSWORD=your-smtp-password
+# TYPO_SNIPER_EMAIL_FROM=alerts@example.com
+# TYPO_SNIPER_EMAIL_TO=soc@example.com,security@example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-08-24
+
+Turns a report generator into a monitoring tool. Scans are now diffed against
+the previous run, alerts fire on what changed, and registration data comes from
+RDAP instead of a port that half the world blocks.
+
+### Added
+
+- **Change detection.** Every scan is compared against the previous one and
+  reports lead with the delta: `NEW` registrations, `ESCALATED` risk, sites that
+  just went live or gained MX records or a certificate (`ACTIVATED`), ownership
+  and hosting `CHANGED`, and squats that `RESOLVED` away. A defender reading a
+  daily report wants to know what moved, not to re-read seventy unchanged rows.
+  The first scan of a domain establishes a baseline silently rather than
+  reporting everything as new.
+- **Alerting** to Slack, Discord, a generic JSON webhook, and email
+  (`--notify slack discord webhook email`). Alerts fire *only* on changes, so a
+  daily schedule stays worth reading. `notify_min_changes` suppresses trivial
+  drift. Endpoints are read from the environment as secrets.
+- **RDAP registration lookup** (RFC 7482), tried before WHOIS. WHOIS needs
+  TCP/43, which is blocked on many corporate networks and in most CI sandboxes,
+  where it fails as a silent timeout — during development of the previous
+  release every one of 67 lookups failed for exactly this reason. RDAP is HTTPS
+  on 443, returns structured JSON with unambiguous timestamps, and shares the
+  scanner's existing async session instead of occupying a worker thread. WHOIS
+  remains the fallback for registries that publish no RDAP endpoint, and reports
+  record which source answered.
+- **Watch mode**: `--watch --interval 6h` runs continuously instead of relying
+  on the compose file's scheduling comment, which never actually scheduled
+  anything. `--interval` accepts `30m`, `6h`, `2d`, or plain seconds.
+- `latest_changes.json` written alongside each report for downstream tooling.
+- Scan history under `state_dir`, retaining `history_retain` scans per domain.
+
+### Changed
+
+- The CLI summary now reports which lookup source answered, and flags notable
+  changes per domain as the scan runs.
+- `--no-rdap`, `--no-diff`, and `--notify-min-changes` added for control.
+
+### Security
+
+- Chat notifiers strip markup-significant characters from domain names,
+  registrant fields, and page titles, all of which are attacker-controlled — the
+  same class of issue fixed in the report exporters in 1.1.0. The JSON webhook
+  deliberately sends values verbatim, because a machine consumer correlates on
+  the exact domain and JSON encoding already prevents structural injection.
+- SMTP failures log the exception type only, never the message body.
+
 ## [1.1.0] - 2026-08-21
 
 A correctness and security release. Report output and risk scores from this

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -22,6 +22,49 @@ dnstwist_phash: false              # Enable perceptual hashing (requires ssdeep)
 # Output settings
 output_dir: results                # Default output directory
 
+# Registration data lookup
+# RDAP (RFC 7482) is tried first: it speaks HTTPS on 443 and returns structured
+# JSON. WHOIS needs TCP/43, which is blocked on many corporate networks and in
+# most CI sandboxes, where it fails as a silent timeout rather than a clear error.
+use_rdap: true
+rdap_timeout: 15
+whois_fallback: true               # Use WHOIS where a registry has no RDAP endpoint
+
+# Change detection
+# Each scan is diffed against the previous one so reports and alerts lead with
+# what changed rather than restating the same results every run.
+enable_diff: true
+state_dir: ~/.typo_sniper/state    # Scan history location
+history_retain: 30                 # Scans kept per monitored domain
+
+# Watch mode (--watch)
+watch_interval: 86400              # Seconds between scans; --interval accepts 6h, 30m
+
+# Notifications - fire on changes only, never on the full result set
+enable_notifications: false
+notify_channels: []                # any of: slack, discord, webhook, email
+notify_timeout: 20
+notify_min_changes: 1              # Suppress alerts below this many changes
+notify_on_no_changes: false        # Send a message even when nothing changed
+
+# Endpoints are secrets: prefer the environment or a secrets manager over this file.
+#   TYPO_SNIPER_SLACK_WEBHOOK_URL, TYPO_SNIPER_DISCORD_WEBHOOK_URL,
+#   TYPO_SNIPER_WEBHOOK_URL, TYPO_SNIPER_WEBHOOK_AUTH_HEADER,
+#   TYPO_SNIPER_SMTP_HOST / _USERNAME / _PASSWORD, TYPO_SNIPER_EMAIL_FROM / _TO
+slack_webhook_url: null
+discord_webhook_url: null
+webhook_url: null
+webhook_auth_header: null          # e.g. "Authorization: Bearer <token>"
+
+smtp_host: null
+smtp_port: 587
+smtp_username: null
+smtp_password: null
+smtp_use_tls: true
+smtp_use_ssl: false
+email_from: null
+email_to: null                     # Comma-separated
+
 # WHOIS settings
 # After 10 consecutive failures the scanner stops retrying for the rest of the
 # run, so a blocked port 43 fails fast instead of multiplying the timeout.

--- a/docs/config.yaml.example
+++ b/docs/config.yaml.example
@@ -22,6 +22,49 @@ dnstwist_phash: false              # Enable perceptual hashing (requires ssdeep)
 # Output settings
 output_dir: results                # Default output directory
 
+# Registration data lookup
+# RDAP (RFC 7482) is tried first: it speaks HTTPS on 443 and returns structured
+# JSON. WHOIS needs TCP/43, which is blocked on many corporate networks and in
+# most CI sandboxes, where it fails as a silent timeout rather than a clear error.
+use_rdap: true
+rdap_timeout: 15
+whois_fallback: true               # Use WHOIS where a registry has no RDAP endpoint
+
+# Change detection
+# Each scan is diffed against the previous one so reports and alerts lead with
+# what changed rather than restating the same results every run.
+enable_diff: true
+state_dir: ~/.typo_sniper/state    # Scan history location
+history_retain: 30                 # Scans kept per monitored domain
+
+# Watch mode (--watch)
+watch_interval: 86400              # Seconds between scans; --interval accepts 6h, 30m
+
+# Notifications - fire on changes only, never on the full result set
+enable_notifications: false
+notify_channels: []                # any of: slack, discord, webhook, email
+notify_timeout: 20
+notify_min_changes: 1              # Suppress alerts below this many changes
+notify_on_no_changes: false        # Send a message even when nothing changed
+
+# Endpoints are secrets: prefer the environment or a secrets manager over this file.
+#   TYPO_SNIPER_SLACK_WEBHOOK_URL, TYPO_SNIPER_DISCORD_WEBHOOK_URL,
+#   TYPO_SNIPER_WEBHOOK_URL, TYPO_SNIPER_WEBHOOK_AUTH_HEADER,
+#   TYPO_SNIPER_SMTP_HOST / _USERNAME / _PASSWORD, TYPO_SNIPER_EMAIL_FROM / _TO
+slack_webhook_url: null
+discord_webhook_url: null
+webhook_url: null
+webhook_auth_header: null          # e.g. "Authorization: Bearer <token>"
+
+smtp_host: null
+smtp_port: 587
+smtp_username: null
+smtp_password: null
+smtp_use_tls: true
+smtp_use_ssl: false
+email_from: null
+email_to: null                     # Comma-separated
+
 # WHOIS settings
 # After 10 consecutive failures the scanner stops retrying for the rest of the
 # run, so a blocked port 43 fails fast instead of multiplying the timeout.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ pythonpath = ["src"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "-q --strict-markers"
+markers = [
+    "allow_network: test may open real network connections (rare; prefer stubs)",
+]
 filterwarnings = [
     "error::DeprecationWarning:src.*",
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -51,6 +51,43 @@ class Config:
     # Output settings
     output_dir: Path = field(default_factory=lambda: Path('results'))
     
+    # Registration data lookup
+    # RDAP (RFC 7482) speaks HTTPS on 443 and returns structured JSON. WHOIS
+    # needs TCP/43, which is blocked on many corporate networks and in most CI
+    # sandboxes, where it fails as a silent timeout rather than a clear error.
+    use_rdap: bool = True
+    rdap_timeout: int = 15
+    whois_fallback: bool = True   # Fall back to WHOIS when RDAP has no endpoint
+
+    # Scan history and change detection
+    enable_diff: bool = True
+    state_dir: Path = field(default_factory=lambda: Path.home() / '.typo_sniper' / 'state')
+    history_retain: int = 30      # Scans kept per monitored domain
+
+    # Watch mode
+    watch_interval: int = 86400   # Seconds between scans when --watch is set
+
+    # Notifications (fire on changes only, never on the full result set)
+    enable_notifications: bool = False
+    notify_channels: list = field(default_factory=list)  # slack, discord, webhook, email
+    notify_timeout: int = 20
+    notify_min_changes: int = 1   # Suppress alerts below this many changes
+    notify_on_no_changes: bool = False
+
+    slack_webhook_url: str | None = None
+    discord_webhook_url: str | None = None
+    webhook_url: str | None = None
+    webhook_auth_header: str | None = None   # e.g. "Authorization: Bearer xyz"
+
+    smtp_host: str | None = None
+    smtp_port: int = 587
+    smtp_username: str | None = None
+    smtp_password: str | None = None
+    smtp_use_tls: bool = True
+    smtp_use_ssl: bool = False
+    email_from: str | None = None
+    email_to: str | None = None   # Comma-separated
+
     # WHOIS settings
     whois_timeout: int = 15
     whois_retry_count: int = 2
@@ -98,6 +135,7 @@ class Config:
         # directory in the working directory.
         self.cache_dir = _expand_path(self.cache_dir)
         self.output_dir = _expand_path(self.output_dir)
+        self.state_dir = _expand_path(self.state_dir)
 
         # Check if Doppler should be used (check for Doppler CLI environment variables)
         if os.getenv('DOPPLER_PROJECT') or os.getenv('DOPPLER_TOKEN') or os.getenv('TYPO_SNIPER_USE_DOPPLER'):
@@ -112,6 +150,29 @@ class Config:
         if not self.urlscan_api_key:
             self.urlscan_api_key = os.getenv('TYPO_SNIPER_URLSCAN_API_KEY') or os.getenv('URLSCAN_API_KEY')
         
+        # Notification endpoints are secrets; accept them from the environment
+        for attr, names in (
+            ('slack_webhook_url', ('TYPO_SNIPER_SLACK_WEBHOOK_URL', 'SLACK_WEBHOOK_URL')),
+            ('discord_webhook_url', ('TYPO_SNIPER_DISCORD_WEBHOOK_URL', 'DISCORD_WEBHOOK_URL')),
+            ('webhook_url', ('TYPO_SNIPER_WEBHOOK_URL',)),
+            ('webhook_auth_header', ('TYPO_SNIPER_WEBHOOK_AUTH_HEADER',)),
+            ('smtp_host', ('TYPO_SNIPER_SMTP_HOST',)),
+            ('smtp_username', ('TYPO_SNIPER_SMTP_USERNAME',)),
+            ('smtp_password', ('TYPO_SNIPER_SMTP_PASSWORD',)),
+            ('email_from', ('TYPO_SNIPER_EMAIL_FROM',)),
+            ('email_to', ('TYPO_SNIPER_EMAIL_TO',)),
+        ):
+            if not getattr(self, attr):
+                for name in names:
+                    value = os.getenv(name)
+                    if value:
+                        setattr(self, attr, value)
+                        break
+
+        # Any configured channel implies notifications are wanted
+        if self.notify_channels and not self.enable_notifications:
+            self.enable_notifications = True
+
         # Load feature flags from environment variables
         enable_urlscan_env = os.getenv('ENABLE_URLSCAN') or os.getenv('TYPO_SNIPER_ENABLE_URLSCAN')
         if enable_urlscan_env:
@@ -191,6 +252,8 @@ class Config:
             data['cache_dir'] = _expand_path(data['cache_dir'])
         if 'output_dir' in data:
             data['output_dir'] = _expand_path(data['output_dir'])
+        if 'state_dir' in data:
+            data['state_dir'] = _expand_path(data['state_dir'])
         
         # Filter only valid fields
         valid_fields = {f.name for f in cls.__dataclass_fields__.values()}

--- a/src/notifiers.py
+++ b/src/notifiers.py
@@ -11,6 +11,10 @@ page titles), so every notifier escapes or plain-texts its content the same way
 the exporters do.
 """
 
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
 import json
 import logging
 import smtplib

--- a/src/notifiers.py
+++ b/src/notifiers.py
@@ -1,0 +1,387 @@
+"""
+Alert delivery for scan deltas.
+
+Notifiers fire on *changes*, never on the full result set. A daily scan that
+re-reported the same seventy registered lookalikes every morning would be
+ignored within a week; one that says "a new lookalike appeared three days ago
+and it has MX records" gets read.
+
+All notifier payloads carry third-party data (domain names, registrant fields,
+page titles), so every notifier escapes or plain-texts its content the same way
+the exporters do.
+"""
+
+import json
+import logging
+import smtplib
+from abc import ABC, abstractmethod
+from email.message import EmailMessage
+from html import escape
+from typing import Any
+
+import aiohttp
+
+from state import ACTIVATED, CHANGED, ESCALATED, NEW, RESOLVED
+
+# Presentation per change kind: (emoji, human label, hex colour)
+KIND_STYLE = {
+    NEW: ('🆕', 'New', '#d73a49'),
+    ESCALATED: ('⚠️', 'Escalated', '#e36209'),
+    ACTIVATED: ('🔔', 'Activated', '#dbab09'),
+    CHANGED: ('✏️', 'Changed', '#0366d6'),
+    RESOLVED: ('✅', 'Resolved', '#28a745'),
+}
+
+# Cap on how many individual changes a single message enumerates
+MAX_ITEMS = 25
+
+
+def _plain(value: Any, limit: int = 120) -> str:
+    """
+    Flatten untrusted text for safe inclusion in a message body.
+
+    Strips control characters and markup-significant characters that could
+    forge formatting or embed links in a chat client.
+    """
+    text = str(value or '')
+    text = ''.join(ch for ch in text if ch.isprintable())
+    for ch in ('`', '*', '_', '~', '|', '<', '>', '[', ']'):
+        text = text.replace(ch, ' ')
+    text = ' '.join(text.split())
+    return text[:limit]
+
+
+def build_lines(summary: dict[str, Any]) -> list[str]:
+    """Render a delta summary as plain-text bullet lines."""
+    lines = []
+    for change in summary.get('changes', [])[:MAX_ITEMS]:
+        emoji, label, _ = KIND_STYLE.get(change['kind'], ('•', change['kind'], '#666'))
+        score = change.get('risk_score')
+        score_text = f" [risk {score}]" if isinstance(score, (int, float)) else ''
+        lines.append(
+            f"{emoji} {label}: {_plain(change['domain'], 80)}{score_text}"
+            f" — {_plain(change.get('detail'), 100)}"
+        )
+
+    remaining = summary.get('total_changes', 0) - MAX_ITEMS
+    if remaining > 0:
+        lines.append(f"…and {remaining} more change(s); see the full report.")
+
+    return lines
+
+
+def build_headline(summary: dict[str, Any]) -> str:
+    """Render a one-line summary of what changed."""
+    counts = summary.get('counts', {})
+    parts = [
+        f"{counts.get(kind, 0)} {KIND_STYLE[kind][1].lower()}"
+        for kind in (NEW, ESCALATED, ACTIVATED, CHANGED)
+        if counts.get(kind, 0)
+    ]
+    return ', '.join(parts) if parts else 'no changes'
+
+
+class BaseNotifier(ABC):
+    """Base class for alert channels."""
+
+    name = 'base'
+
+    def __init__(self, config):
+        self.config = config
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    @abstractmethod
+    async def send(self, summary: dict[str, Any], session: aiohttp.ClientSession) -> bool:
+        """
+        Deliver an alert.
+
+        Args:
+            summary: Aggregate delta summary
+            session: Shared aiohttp session
+
+        Returns:
+            True when delivery succeeded
+        """
+
+    async def _post_json(
+        self, url: str, payload: dict, session: aiohttp.ClientSession
+    ) -> bool:
+        """POST a JSON body, treating any 2xx as success."""
+        try:
+            timeout = aiohttp.ClientTimeout(total=self.config.notify_timeout)
+            async with session.post(url, json=payload, timeout=timeout) as response:
+                if 200 <= response.status < 300:
+                    self.logger.info(f"{self.name} alert delivered")
+                    return True
+                body = (await response.text())[:200]
+                self.logger.error(
+                    f"{self.name} alert failed: HTTP {response.status} {body}"
+                )
+                return False
+        except Exception as e:
+            self.logger.error(f"{self.name} alert failed: {e}")
+            return False
+
+
+class SlackNotifier(BaseNotifier):
+    """Post delta alerts to a Slack incoming webhook."""
+
+    name = 'Slack'
+
+    async def send(self, summary, session) -> bool:
+        url = self.config.slack_webhook_url
+        if not url:
+            return False
+
+        headline = build_headline(summary)
+        lines = build_lines(summary)
+
+        blocks = [
+            {
+                'type': 'header',
+                'text': {
+                    'type': 'plain_text',
+                    'text': f'🎯 Typo Sniper: {headline}',
+                },
+            }
+        ]
+
+        if lines:
+            # Slack caps a section at 3000 characters
+            body = '\n'.join(lines)[:2900]
+            blocks.append({
+                'type': 'section',
+                'text': {'type': 'mrkdwn', 'text': body},
+            })
+
+        blocks.append({
+            'type': 'context',
+            'elements': [{
+                'type': 'mrkdwn',
+                'text': (
+                    f"{summary.get('total_changes', 0)} change(s) across "
+                    f"monitored domains"
+                ),
+            }],
+        })
+
+        return await self._post_json(
+            url, {'text': f'Typo Sniper: {headline}', 'blocks': blocks}, session
+        )
+
+
+class DiscordNotifier(BaseNotifier):
+    """Post delta alerts to a Discord webhook."""
+
+    name = 'Discord'
+
+    async def send(self, summary, session) -> bool:
+        url = self.config.discord_webhook_url
+        if not url:
+            return False
+
+        headline = build_headline(summary)
+        lines = build_lines(summary)
+
+        # Colour the embed by the most severe change present
+        colour = 0x28A745
+        for kind in (NEW, ESCALATED, ACTIVATED, CHANGED):
+            if summary.get('counts', {}).get(kind):
+                colour = int(KIND_STYLE[kind][2].lstrip('#'), 16)
+                break
+
+        embed = {
+            'title': f'🎯 Typo Sniper: {headline}',
+            'color': colour,
+            'description': '\n'.join(lines)[:4000] or 'No changes to report.',
+            'footer': {'text': f"{summary.get('total_changes', 0)} change(s)"},
+        }
+
+        return await self._post_json(url, {'embeds': [embed]}, session)
+
+
+class WebhookNotifier(BaseNotifier):
+    """
+    POST the delta summary to a generic HTTP endpoint as JSON.
+
+    Unlike the chat notifiers, this one deliberately sends values verbatim.
+    The consumer is a machine — a SIEM, a ticketing system, a script — and a
+    domain name is the primary key it will correlate on, so mangling
+    ``g00gle<script>.com`` into something prettier would corrupt the very
+    field that matters. JSON encoding already prevents the payload from
+    breaking out of its structure; escaping for presentation is the
+    consumer's job at the point of rendering.
+    """
+
+    name = 'Webhook'
+
+    async def send(self, summary, session) -> bool:
+        url = self.config.webhook_url
+        if not url:
+            return False
+
+        payload = {
+            'source': 'typo-sniper',
+            'headline': build_headline(summary),
+            'counts': summary.get('counts', {}),
+            'total_changes': summary.get('total_changes', 0),
+            'changes': [
+                {
+                    'kind': c['kind'],
+                    'domain': c['domain'],
+                    'monitored_domain': c.get('monitored_domain'),
+                    'risk_score': c.get('risk_score'),
+                    'detail': c.get('detail'),
+                }
+                for c in summary.get('changes', [])
+            ],
+        }
+
+        headers = {}
+        if self.config.webhook_auth_header:
+            # Split once so a bearer token containing ":" survives intact
+            key, _, value = self.config.webhook_auth_header.partition(':')
+            if value:
+                headers[key.strip()] = value.strip()
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=self.config.notify_timeout)
+            async with session.post(
+                url, json=payload, headers=headers, timeout=timeout
+            ) as response:
+                if 200 <= response.status < 300:
+                    self.logger.info('Webhook alert delivered')
+                    return True
+                self.logger.error(f'Webhook alert failed: HTTP {response.status}')
+                return False
+        except Exception as e:
+            self.logger.error(f'Webhook alert failed: {e}')
+            return False
+
+
+class EmailNotifier(BaseNotifier):
+    """Send delta alerts over SMTP."""
+
+    name = 'Email'
+
+    async def send(self, summary, session) -> bool:
+        if not (self.config.smtp_host and self.config.email_to):
+            return False
+
+        import asyncio
+
+        # smtplib is blocking; keep it off the event loop
+        return await asyncio.get_event_loop().run_in_executor(
+            None, self._send_sync, summary
+        )
+
+    def _send_sync(self, summary: dict[str, Any]) -> bool:
+        """Build and deliver the message synchronously."""
+        headline = build_headline(summary)
+        lines = build_lines(summary)
+
+        message = EmailMessage()
+        message['Subject'] = f'[Typo Sniper] {headline}'
+        message['From'] = self.config.email_from or self.config.smtp_username
+        message['To'] = ', '.join(
+            a.strip() for a in self.config.email_to.split(',') if a.strip()
+        )
+        message.set_content(
+            'Typo Sniper detected the following changes:\n\n'
+            + '\n'.join(lines)
+            + '\n\nSee the attached report directory for full detail.\n'
+        )
+
+        rows = ''.join(
+            f'<tr><td>{escape(KIND_STYLE.get(c["kind"], ("", c["kind"], ""))[1])}</td>'
+            f'<td><code>{escape(_plain(c["domain"], 80))}</code></td>'
+            f'<td>{escape(str(c.get("risk_score") or ""))}</td>'
+            f'<td>{escape(_plain(c.get("detail"), 120))}</td></tr>'
+            for c in summary.get('changes', [])[:MAX_ITEMS]
+        )
+        message.add_alternative(
+            f'<html><body><h2>Typo Sniper: {escape(headline)}</h2>'
+            '<table border="1" cellpadding="6" cellspacing="0">'
+            '<tr><th>Change</th><th>Domain</th><th>Risk</th><th>Detail</th></tr>'
+            f'{rows}</table></body></html>',
+            subtype='html',
+        )
+
+        try:
+            if self.config.smtp_use_ssl:
+                server = smtplib.SMTP_SSL(
+                    self.config.smtp_host, self.config.smtp_port, timeout=30
+                )
+            else:
+                server = smtplib.SMTP(
+                    self.config.smtp_host, self.config.smtp_port, timeout=30
+                )
+
+            with server:
+                if self.config.smtp_use_tls and not self.config.smtp_use_ssl:
+                    server.starttls()
+                if self.config.smtp_username:
+                    server.login(self.config.smtp_username, self.config.smtp_password or '')
+                server.send_message(message)
+
+            self.logger.info('Email alert delivered')
+            return True
+        except Exception as e:
+            # The exception type only: SMTP errors can echo message content
+            self.logger.error(f'Email alert failed ({type(e).__name__})')
+            return False
+
+
+NOTIFIERS = {
+    'slack': SlackNotifier,
+    'discord': DiscordNotifier,
+    'webhook': WebhookNotifier,
+    'email': EmailNotifier,
+}
+
+
+async def dispatch(
+    summary: dict[str, Any], config, session: aiohttp.ClientSession
+) -> dict[str, bool]:
+    """
+    Send the delta summary through every configured channel.
+
+    Args:
+        summary: Aggregate delta summary
+        config: Configuration object
+        session: Shared aiohttp session
+
+    Returns:
+        Mapping of channel name to delivery success
+    """
+    logger = logging.getLogger(__name__)
+
+    if not config.enable_notifications:
+        return {}
+
+    if not summary.get('has_alerts') and not config.notify_on_no_changes:
+        logger.debug('No actionable changes; skipping notifications')
+        return {}
+
+    if summary.get('actionable', 0) < config.notify_min_changes:
+        logger.debug(
+            f"Only {summary.get('actionable', 0)} change(s), below "
+            f"notify_min_changes={config.notify_min_changes}"
+        )
+        return {}
+
+    results = {}
+    for name in config.notify_channels:
+        notifier_cls = NOTIFIERS.get(name.lower())
+        if not notifier_cls:
+            logger.warning(f'Unknown notification channel: {name}')
+            continue
+        results[name] = await notifier_cls(config).send(summary, session)
+
+    return results
+
+
+def write_delta_json(summary: dict[str, Any], path) -> None:
+    """Write the delta summary to disk for downstream tooling."""
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)

--- a/src/rdap.py
+++ b/src/rdap.py
@@ -1,0 +1,361 @@
+"""
+RDAP (Registration Data Access Protocol) client.
+
+RDAP is the IETF successor to WHOIS (RFC 7482/7483). It matters here for three
+reasons:
+
+  * It speaks HTTPS on port 443. Port 43, which WHOIS needs, is blocked on many
+    corporate networks and in most CI sandboxes, where it fails as a silent
+    timeout rather than a clear error.
+  * It returns structured JSON with ISO-8601 timestamps, instead of free-form
+    text whose date format varies per registry.
+  * It is a normal HTTP request, so it shares the scanner's existing aiohttp
+    session and concurrency limits rather than occupying a worker thread.
+
+WHOIS remains available as a fallback for registries that do not publish an
+RDAP endpoint.
+"""
+
+import asyncio
+import logging
+from datetime import date, datetime, timezone
+from typing import Any
+
+import aiohttp
+
+# IANA's authoritative map of TLD -> RDAP service base URL (RFC 7484)
+BOOTSTRAP_URL = "https://data.iana.org/rdap/dns.json"
+
+# Registries that do not publish to the IANA bootstrap file but do serve RDAP
+EXTRA_ENDPOINTS = {
+    'ai': 'https://rdap.identitydigital.services/rdap/',
+    'io': 'https://rdap.identitydigital.services/rdap/',
+    'sh': 'https://rdap.identitydigital.services/rdap/',
+}
+
+
+class RDAPClient:
+    """Look up domain registration data over RDAP."""
+
+    def __init__(self, session: aiohttp.ClientSession, config, cache=None):
+        """
+        Args:
+            session: Shared aiohttp session
+            config: Configuration object
+            cache: Optional Cache for the bootstrap registry and lookups
+        """
+        self.session = session
+        self.config = config
+        self.cache = cache
+        self.logger = logging.getLogger(__name__)
+        self._bootstrap: dict[str, str] | None = None
+        self._bootstrap_lock = asyncio.Lock()
+
+    # -- bootstrap ---------------------------------------------------------
+
+    async def _load_bootstrap(self) -> dict[str, str]:
+        """
+        Fetch and index IANA's TLD -> RDAP endpoint map.
+
+        Returns:
+            Mapping of lowercase TLD to RDAP base URL (trailing slash included)
+        """
+        async with self._bootstrap_lock:
+            if self._bootstrap is not None:
+                return self._bootstrap
+
+            # The registry changes rarely; a cached copy avoids one request per run
+            if self.cache:
+                cached = self.cache.get('rdap:bootstrap')
+                if cached and isinstance(cached, dict) and cached.get('map'):
+                    self._bootstrap = cached['map']
+                    return self._bootstrap
+
+            mapping: dict[str, str] = {}
+            try:
+                timeout = aiohttp.ClientTimeout(total=self.config.rdap_timeout)
+                async with self.session.get(BOOTSTRAP_URL, timeout=timeout) as response:
+                    if response.status == 200:
+                        data = await response.json(content_type=None)
+                        for entry in data.get('services', []):
+                            if len(entry) < 2:
+                                continue
+                            tlds, urls = entry[0], entry[1]
+                            https = [u for u in urls if u.startswith('https://')]
+                            base = (https or urls or [None])[0]
+                            if not base:
+                                continue
+                            if not base.endswith('/'):
+                                base += '/'
+                            for tld in tlds:
+                                mapping[tld.lower().lstrip('.')] = base
+                    else:
+                        self.logger.warning(
+                            f"RDAP bootstrap returned HTTP {response.status}"
+                        )
+            except Exception as e:
+                self.logger.warning(f"Could not load RDAP bootstrap registry: {e}")
+
+            for tld, base in EXTRA_ENDPOINTS.items():
+                mapping.setdefault(tld, base)
+
+            self._bootstrap = mapping
+
+            if self.cache and mapping:
+                # Refreshed weekly: new TLDs appear rarely
+                self.cache.set('rdap:bootstrap', {'map': mapping}, ttl=604800)
+
+            self.logger.debug(f"RDAP bootstrap loaded: {len(mapping)} TLDs")
+            return mapping
+
+    async def endpoint_for(self, domain: str) -> str | None:
+        """
+        Resolve the RDAP base URL that serves a domain's TLD.
+
+        Args:
+            domain: Domain name
+
+        Returns:
+            Base URL, or None when the registry publishes no RDAP service
+        """
+        bootstrap = await self._load_bootstrap()
+        labels = domain.lower().rstrip('.').split('.')
+
+        # Try the longest suffix first so that multi-label registries
+        # (e.g. "co.uk") win over the bare TLD when both are published.
+        # The range must reach the final label, otherwise a plain
+        # "example.com" never gets matched against the "com" entry.
+        for i in range(len(labels)):
+            suffix = '.'.join(labels[i:])
+            if suffix in bootstrap:
+                return bootstrap[suffix]
+
+        return None
+
+    # -- lookup ------------------------------------------------------------
+
+    async def lookup(self, domain: str) -> dict[str, Any] | None:
+        """
+        Fetch registration data for a domain.
+
+        Args:
+            domain: Domain to look up
+
+        Returns:
+            Normalised registration dictionary, or None if RDAP could not
+            answer (no endpoint, network failure, or an unregistered domain)
+        """
+        base = await self.endpoint_for(domain)
+        if not base:
+            self.logger.debug(f"No RDAP endpoint published for {domain}")
+            return None
+
+        url = f"{base}domain/{domain}"
+        timeout = aiohttp.ClientTimeout(total=self.config.rdap_timeout)
+
+        for attempt in range(2):
+            try:
+                async with self.session.get(
+                    url,
+                    timeout=timeout,
+                    headers={'Accept': 'application/rdap+json'},
+                    allow_redirects=True,
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json(content_type=None)
+                        return self.parse(data)
+
+                    if response.status == 404:
+                        # Authoritative: the registry has no such registration
+                        self.logger.debug(f"RDAP reports {domain} unregistered")
+                        return None
+
+                    if response.status == 429 and attempt == 0:
+                        await asyncio.sleep(2)
+                        continue
+
+                    self.logger.debug(f"RDAP HTTP {response.status} for {domain}")
+                    return None
+
+            except asyncio.TimeoutError:
+                self.logger.debug(f"RDAP timeout for {domain}")
+                return None
+            except Exception as e:
+                self.logger.debug(f"RDAP lookup failed for {domain}: {e}")
+                return None
+
+        return None
+
+    # -- parsing -----------------------------------------------------------
+
+    @staticmethod
+    def parse(data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Convert an RDAP domain response into the scanner's registration shape.
+
+        The output keys match those produced by the WHOIS path so that
+        exporters, risk scoring, and the diff engine stay source-agnostic.
+
+        Args:
+            data: Parsed RDAP JSON
+
+        Returns:
+            Normalised registration dictionary
+        """
+        events = RDAPClient._parse_events(data.get('events') or [])
+        registrar, registrant, org, emails, country = RDAPClient._parse_entities(
+            data.get('entities') or []
+        )
+
+        name_servers = []
+        for ns in data.get('nameservers') or []:
+            name = ns.get('ldhName') or ns.get('unicodeName')
+            if name:
+                name_servers.append(str(name).lower().rstrip('.'))
+
+        status = data.get('status') or []
+        if isinstance(status, str):
+            status = [status]
+
+        return {
+            'whois_created': events.get('registration', []),
+            'whois_updated': events.get('last changed', []),
+            'whois_expires': events.get('expiration', []),
+            'whois_registrant': registrant,
+            'whois_org': org,
+            'whois_registrar': registrar,
+            'whois_emails': emails,
+            'whois_name_servers': name_servers,
+            'whois_status': list(status),
+            'whois_country': country,
+            'registration_source': 'rdap',
+        }
+
+    @staticmethod
+    def _parse_events(events: list) -> dict[str, list[str]]:
+        """Index RDAP events by action, as ISO date strings."""
+        out: dict[str, list[str]] = {}
+
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            action = str(event.get('eventAction', '')).lower()
+            raw = event.get('eventDate')
+            if not action or not raw:
+                continue
+
+            parsed = RDAPClient._parse_timestamp(raw)
+            if parsed:
+                out.setdefault(action, []).append(parsed)
+
+        return out
+
+    @staticmethod
+    def _parse_timestamp(value: Any) -> str | None:
+        """Normalise an RDAP timestamp to an ISO date string."""
+        if isinstance(value, datetime):
+            return value.date().isoformat()
+        if isinstance(value, date):
+            return value.isoformat()
+        if not isinstance(value, str):
+            return None
+
+        text = value.strip()
+        try:
+            # RDAP mandates RFC 3339; "Z" needs translating for fromisoformat
+            dt = datetime.fromisoformat(text.replace('Z', '+00:00'))
+            if dt.tzinfo:
+                dt = dt.astimezone(timezone.utc)
+            return dt.date().isoformat()
+        except ValueError:
+            pass
+
+        try:
+            return date.fromisoformat(text[:10]).isoformat()
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_entities(entities: list):
+        """
+        Extract registrar, registrant, organisation, emails and country.
+
+        Returns:
+            Tuple of (registrar, registrant, org, emails, country)
+        """
+        registrar = registrant = org = country = None
+        emails: list[str] = []
+
+        for entity in entities:
+            if not isinstance(entity, dict):
+                continue
+
+            roles = [str(r).lower() for r in (entity.get('roles') or [])]
+            fields = RDAPClient._parse_vcard(entity.get('vcardArray'))
+
+            for address in fields.get('emails', []):
+                if address not in emails:
+                    emails.append(address)
+
+            if 'registrar' in roles:
+                registrar = fields.get('fn') or registrar
+                # Registrars also publish an IANA ID; prefer the human name
+                if not registrar:
+                    for pid in entity.get('publicIds') or []:
+                        if isinstance(pid, dict) and pid.get('identifier'):
+                            registrar = f"IANA {pid['identifier']}"
+                            break
+
+            if 'registrant' in roles:
+                registrant = fields.get('fn') or registrant
+                org = fields.get('org') or org
+                country = fields.get('country') or country
+
+            # Nested entities carry the registrar's abuse contacts
+            nested = entity.get('entities')
+            if nested:
+                sub = RDAPClient._parse_entities(nested)
+                for address in sub[3]:
+                    if address not in emails:
+                        emails.append(address)
+
+        return registrar, registrant, org, emails, country
+
+    @staticmethod
+    def _parse_vcard(vcard: Any) -> dict[str, Any]:
+        """
+        Pull useful fields out of a jCard array (RFC 7095).
+
+        A jCard looks like ["vcard", [["fn", {}, "text", "Example Inc"], ...]].
+        """
+        out: dict[str, Any] = {'emails': []}
+
+        if not isinstance(vcard, list) or len(vcard) < 2:
+            return out
+        if not isinstance(vcard[1], list):
+            return out
+
+        for entry in vcard[1]:
+            if not isinstance(entry, list) or len(entry) < 4:
+                continue
+
+            name = str(entry[0]).lower()
+            value = entry[3]
+
+            if name == 'fn' and isinstance(value, str) and value.strip():
+                out['fn'] = value.strip()
+            elif name == 'org':
+                # org may be a string or a structured list
+                if isinstance(value, list):
+                    value = ' '.join(str(v) for v in value if v)
+                if isinstance(value, str) and value.strip():
+                    out['org'] = value.strip()
+            elif name == 'email' and isinstance(value, str) and '@' in value:
+                out['emails'].append(value.strip())
+            elif name == 'adr' and isinstance(value, list) and len(value) >= 7:
+                # jCard address: [pobox, ext, street, locality, region, code, country]
+                candidate = value[6]
+                if isinstance(candidate, str) and candidate.strip():
+                    out['country'] = candidate.strip()
+
+        return out

--- a/src/rdap.py
+++ b/src/rdap.py
@@ -16,6 +16,10 @@ WHOIS remains available as a fallback for registries that do not publish an
 RDAP endpoint.
 """
 
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
 import asyncio
 import logging
 from datetime import date, datetime, timezone

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -16,12 +16,14 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime
 from typing import Any
 
+import aiohttp
 import dnstwist
 import whois
 
 from cache import Cache
 from config import Config
 from enhanced_detection import SoundAlikeDetector, generate_enhanced_permutations
+from rdap import RDAPClient
 from threat_intelligence import ThreatIntelligence, calculate_risk_score
 from utils import clean_dns_records, is_registered
 
@@ -54,6 +56,8 @@ class DomainScanner:
         # consecutive failures, fall back to a single attempt per domain.
         self._whois_consecutive_failures = 0
         self._whois_circuit_open = False
+        # Per-run counts of where registration data actually came from
+        self.lookup_sources = {'rdap': 0, 'whois': 0, 'none': 0}
 
     def close(self) -> None:
         """Shut down the worker thread pool."""
@@ -107,8 +111,23 @@ class DomainScanner:
 
         whois_before = self.whois_succeeded
 
-        # Enrich with WHOIS data
-        enriched = await self._enrich_with_whois(registered)
+        # Registration data: RDAP first (HTTPS, structured JSON), falling back
+        # to WHOIS only for registries that publish no RDAP endpoint.
+        needs_whois = registered
+        if self.config.use_rdap:
+            unresolved = await self._enrich_with_rdap(registered)
+            needs_whois = [p for p in registered if p['domain'] in unresolved]
+            if needs_whois and not self.config.whois_fallback:
+                self.logger.info(
+                    f"{len(needs_whois)} domains unresolved by RDAP; "
+                    f"WHOIS fallback is disabled"
+                )
+                needs_whois = []
+
+        if needs_whois:
+            await self._enrich_with_whois(needs_whois)
+
+        enriched = registered
 
         # Derive registration age from the WHOIS data. This must happen before
         # risk scoring, which weights recently registered domains most heavily.
@@ -148,7 +167,7 @@ class DomainScanner:
                 f"No WHOIS data could be retrieved for any of the {len(registered)} "
                 f"registered permutations of {domain}. Registration dates and "
                 f"recency scoring will be missing from this report. Check outbound "
-                f"access to WHOIS servers on TCP port 43."
+                f"access to RDAP endpoints (HTTPS) and WHOIS servers (TCP/43)."
             )
 
         return {
@@ -159,6 +178,7 @@ class DomainScanner:
             'filtered_count': len(enriched),
             'whois_succeeded': whois_ok,
             'whois_failed': len(registered) - whois_ok,
+            'lookup_sources': dict(self.lookup_sources),
             'permutations': enriched
         }
 
@@ -447,6 +467,69 @@ class DomainScanner:
         
         return permutations
 
+    async def _enrich_with_rdap(self, permutations: list[dict[str, Any]]) -> set:
+        """
+        Enrich permutations with RDAP registration data.
+
+        Args:
+            permutations: Permutation dictionaries, updated in place
+
+        Returns:
+            Set of domain names RDAP could not answer for, which the caller
+            may retry over WHOIS
+        """
+        unresolved: set = set()
+        if not permutations:
+            return unresolved
+
+        connector = aiohttp.TCPConnector(limit=max(4, self.config.max_workers * 2))
+        timeout = aiohttp.ClientTimeout(total=self.config.rdap_timeout + 10)
+
+        async with aiohttp.ClientSession(
+            connector=connector,
+            timeout=timeout,
+            headers={'User-Agent': self.config.user_agent},
+        ) as session:
+            client = RDAPClient(session, self.config, self.cache)
+            semaphore = asyncio.Semaphore(max(1, self.config.max_workers))
+
+            async def lookup_one(perm):
+                domain = perm['domain']
+
+                if self.config.use_cache:
+                    cached = self.cache.get(f"rdap:{domain}")
+                    if cached:
+                        perm.update(cached)
+                        return 'rdap'
+
+                async with semaphore:
+                    data = await client.lookup(domain)
+
+                if data:
+                    perm.update(data)
+                    if self.config.use_cache:
+                        self.cache.set(f"rdap:{domain}", data, ttl=self.config.cache_ttl)
+                    return 'rdap'
+                return None
+
+            results = await asyncio.gather(
+                *(lookup_one(p) for p in permutations), return_exceptions=True
+            )
+
+        resolved = 0
+        for perm, outcome in zip(permutations, results, strict=False):
+            if outcome == 'rdap':
+                resolved += 1
+                self.lookup_sources['rdap'] += 1
+                self.whois_succeeded += 1
+            else:
+                if isinstance(outcome, Exception):
+                    self.logger.debug(f"RDAP error for {perm['domain']}: {outcome}")
+                unresolved.add(perm['domain'])
+
+        self.logger.info(f"RDAP resolved {resolved}/{len(permutations)} domains")
+        return unresolved
+
     async def _enrich_with_whois(self, permutations: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
         Enrich permutations with WHOIS data.
@@ -526,8 +609,11 @@ class DomainScanner:
 
             if whois_data:
                 self.whois_succeeded += 1
+                self.lookup_sources['whois'] += 1
+                whois_data.setdefault('registration_source', 'whois')
             else:
                 self.whois_failed += 1
+                self.lookup_sources['none'] += 1
 
             return whois_data
 

--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,373 @@
+"""
+Scan history and change detection.
+
+A defender running this daily does not want to re-read the same seventy rows
+every morning; they want to know what changed. This module persists each scan
+and diffs the current one against the previous, so reports and alerts can lead
+with new registrations, newly activated sites, and escalating risk instead of
+restating the steady state.
+"""
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+# Fields whose change is meaningful enough to report. Each entry maps the
+# permutation key to the label used in reports and alerts.
+TRACKED_FIELDS = {
+    'risk_score': 'risk score',
+    'created_days_ago': 'registration age',
+    'whois_registrar': 'registrar',
+    'whois_org': 'organization',
+    'whois_registrant': 'registrant',
+}
+
+# Change kinds, ordered by how much they warrant attention
+NEW = 'new'
+ESCALATED = 'escalated'
+ACTIVATED = 'activated'
+CHANGED = 'changed'
+RESOLVED = 'resolved'
+
+SEVERITY_ORDER = [NEW, ESCALATED, ACTIVATED, CHANGED, RESOLVED]
+
+
+class ScanHistory:
+    """Persist scan results and compute deltas between runs."""
+
+    def __init__(self, state_dir: Path, retain: int = 30):
+        """
+        Args:
+            state_dir: Directory holding per-domain history files
+            retain: Number of historical scans to keep per domain
+        """
+        self.state_dir = Path(state_dir)
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.retain = max(1, retain)
+        self.logger = logging.getLogger(__name__)
+
+    def _path_for(self, domain: str) -> Path:
+        """Return the history file for a monitored domain."""
+        import hashlib
+
+        # The domain is used for the filename; hash it so that unusual
+        # characters and length limits cannot produce an invalid path.
+        digest = hashlib.sha256(domain.lower().encode()).hexdigest()[:32]
+        return self.state_dir / f"{digest}.json"
+
+    def load(self, domain: str) -> list[dict[str, Any]]:
+        """
+        Load the stored scan history for a domain, newest first.
+
+        Args:
+            domain: Monitored domain
+
+        Returns:
+            List of stored scan snapshots
+        """
+        path = self._path_for(domain)
+        if not path.exists():
+            return []
+
+        try:
+            with open(path, encoding='utf-8') as f:
+                data = json.load(f)
+            scans = data.get('scans', [])
+            return scans if isinstance(scans, list) else []
+        except (OSError, json.JSONDecodeError) as e:
+            self.logger.warning(f"Could not read scan history for {domain}: {e}")
+            return []
+
+    def record(self, result: dict[str, Any]) -> None:
+        """
+        Append a scan result to the domain's history.
+
+        Only the fields needed for diffing are stored, so history files stay
+        small enough to keep many scans without bloating the state directory.
+
+        Args:
+            result: Scan result dictionary from the scanner
+        """
+        domain = result.get('original_domain')
+        if not domain:
+            return
+
+        snapshot = {
+            'scan_date': result.get('scan_date'),
+            'recorded_at': time.time(),
+            'registered_count': result.get('registered_count', 0),
+            'permutations': {
+                p['domain']: self._snapshot_permutation(p)
+                for p in result.get('permutations', [])
+                if p.get('domain')
+            },
+        }
+
+        scans = self.load(domain)
+        scans.insert(0, snapshot)
+        del scans[self.retain:]
+
+        path = self._path_for(domain)
+        try:
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump({'domain': domain, 'scans': scans}, f, indent=2)
+        except OSError as e:
+            self.logger.warning(f"Could not write scan history for {domain}: {e}")
+
+    @staticmethod
+    def _snapshot_permutation(perm: dict[str, Any]) -> dict[str, Any]:
+        """Reduce a permutation to the fields that diffing needs."""
+        threat = perm.get('threat_intel') or {}
+        http = threat.get('http_probe') or {}
+        ct = threat.get('certificate_transparency') or {}
+        urlscan = threat.get('urlscan') or {}
+
+        return {
+            'fuzzer': perm.get('fuzzer'),
+            'risk_score': perm.get('risk_score'),
+            'created_days_ago': perm.get('created_days_ago'),
+            'is_recent': perm.get('is_recent', False),
+            'dns_a': list(perm.get('dns_a') or []),
+            'dns_mx': list(perm.get('dns_mx') or []),
+            'whois_registrar': perm.get('whois_registrar'),
+            'whois_org': perm.get('whois_org'),
+            'whois_registrant': perm.get('whois_registrant'),
+            'http_active': bool(http.get('http_active')),
+            'https_active': bool(http.get('https_active')),
+            'tls_verified': http.get('tls_verified'),
+            'title': http.get('title'),
+            'certificates_found': ct.get('certificates_found', 0),
+            'urlscan_malicious': bool(urlscan.get('malicious')),
+        }
+
+    # -- diffing -----------------------------------------------------------
+
+    def diff(self, result: dict[str, Any]) -> dict[str, Any]:
+        """
+        Compare a fresh scan against the most recent stored scan.
+
+        Args:
+            result: Scan result dictionary from the scanner
+
+        Returns:
+            Delta report with 'baseline' (None on first run) and 'changes'
+        """
+        domain = result.get('original_domain')
+        history = self.load(domain) if domain else []
+
+        current = {
+            p['domain']: self._snapshot_permutation(p)
+            for p in result.get('permutations', [])
+            if p.get('domain')
+        }
+
+        if not history:
+            # First run establishes the baseline. Reporting seventy domains as
+            # "new" would be noise, not signal, so they are counted instead.
+            return {
+                'domain': domain,
+                'baseline': None,
+                'first_run': True,
+                'changes': [],
+                'counts': {NEW: 0, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0},
+                'total_current': len(current),
+            }
+
+        previous_scan = history[0]
+        previous = previous_scan.get('permutations', {})
+        changes: list[dict[str, Any]] = []
+
+        for name, now in current.items():
+            before = previous.get(name)
+
+            if before is None:
+                changes.append({
+                    'kind': NEW,
+                    'domain': name,
+                    'risk_score': now.get('risk_score'),
+                    'detail': self._describe_new(now),
+                    'current': now,
+                })
+                continue
+
+            changes.extend(self._compare(name, before, now))
+
+        for name, before in previous.items():
+            if name not in current:
+                changes.append({
+                    'kind': RESOLVED,
+                    'domain': name,
+                    'risk_score': before.get('risk_score'),
+                    'detail': 'no longer resolves',
+                    'current': None,
+                })
+
+        counts = dict.fromkeys(SEVERITY_ORDER, 0)
+        for change in changes:
+            counts[change['kind']] = counts.get(change['kind'], 0) + 1
+
+        changes.sort(key=lambda c: (
+            SEVERITY_ORDER.index(c['kind']),
+            -(c.get('risk_score') or 0),
+            c['domain'],
+        ))
+
+        return {
+            'domain': domain,
+            'baseline': previous_scan.get('scan_date'),
+            'first_run': False,
+            'changes': changes,
+            'counts': counts,
+            'total_current': len(current),
+        }
+
+    def _compare(self, name: str, before: dict, now: dict) -> list[dict[str, Any]]:
+        """Compare one permutation across two scans."""
+        changes = []
+
+        # A parked domain that starts serving content is the transition that
+        # most often precedes an actual phishing campaign.
+        was_live = before.get('http_active') or before.get('https_active')
+        is_live = now.get('http_active') or now.get('https_active')
+        if is_live and not was_live:
+            changes.append({
+                'kind': ACTIVATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': 'started serving content',
+                'current': now,
+            })
+
+        # Newly able to send and receive mail
+        if now.get('dns_mx') and not before.get('dns_mx'):
+            changes.append({
+                'kind': ACTIVATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': 'added mail servers (MX)',
+                'current': now,
+            })
+
+        # Newly obtained a certificate
+        if now.get('certificates_found', 0) > 0 and before.get('certificates_found', 0) == 0:
+            changes.append({
+                'kind': ACTIVATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': 'obtained a TLS certificate',
+                'current': now,
+            })
+
+        if now.get('urlscan_malicious') and not before.get('urlscan_malicious'):
+            changes.append({
+                'kind': ESCALATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': 'flagged malicious by URLScan',
+                'current': now,
+            })
+
+        old_score = before.get('risk_score')
+        new_score = now.get('risk_score')
+        if isinstance(old_score, (int, float)) and isinstance(new_score, (int, float)):
+            if new_score - old_score >= 10:
+                changes.append({
+                    'kind': ESCALATED,
+                    'domain': name,
+                    'risk_score': new_score,
+                    'detail': f'risk score rose {old_score} -> {new_score}',
+                    'current': now,
+                })
+
+        # Ownership changes: a transferred lookalike often signals resale to
+        # someone with a use for it
+        for field, label in TRACKED_FIELDS.items():
+            if field in ('risk_score', 'created_days_ago'):
+                continue
+            old_value, new_value = before.get(field), now.get(field)
+            if old_value != new_value and (old_value or new_value):
+                changes.append({
+                    'kind': CHANGED,
+                    'domain': name,
+                    'risk_score': new_score,
+                    'detail': f'{label}: {old_value or "none"} -> {new_value or "none"}',
+                    'current': now,
+                })
+
+        # A changed IP can mean re-hosting onto bulletproof infrastructure
+        if set(now.get('dns_a') or []) != set(before.get('dns_a') or []):
+            if before.get('dns_a'):
+                changes.append({
+                    'kind': CHANGED,
+                    'domain': name,
+                    'risk_score': new_score,
+                    'detail': (
+                        f'IP changed: {", ".join(before.get("dns_a") or []) or "none"}'
+                        f' -> {", ".join(now.get("dns_a") or []) or "none"}'
+                    ),
+                    'current': now,
+                })
+
+        return changes
+
+    @staticmethod
+    def _describe_new(now: dict[str, Any]) -> str:
+        """Summarise why a newly seen domain matters."""
+        bits = []
+        age = now.get('created_days_ago')
+        if isinstance(age, (int, float)):
+            bits.append(f'registered {int(age)}d ago')
+        if now.get('dns_mx'):
+            bits.append('has MX')
+        if now.get('https_active'):
+            bits.append('serving HTTPS')
+        elif now.get('http_active'):
+            bits.append('serving HTTP')
+        if now.get('tls_verified') is False:
+            bits.append('invalid certificate')
+        return 'newly detected' + (' (' + ', '.join(bits) + ')' if bits else '')
+
+
+def summarize(deltas: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Combine per-domain deltas into one run-level summary.
+
+    Args:
+        deltas: Delta reports, one per monitored domain
+
+    Returns:
+        Aggregate counts, the full change list, and whether anything is worth
+        alerting on
+    """
+    counts = dict.fromkeys(SEVERITY_ORDER, 0)
+    changes: list[dict[str, Any]] = []
+    first_runs = []
+
+    for delta in deltas:
+        if delta.get('first_run'):
+            first_runs.append(delta.get('domain'))
+            continue
+        for kind, n in (delta.get('counts') or {}).items():
+            counts[kind] = counts.get(kind, 0) + n
+        for change in delta.get('changes', []):
+            changes.append({**change, 'monitored_domain': delta.get('domain')})
+
+    changes.sort(key=lambda c: (
+        SEVERITY_ORDER.index(c['kind']),
+        -(c.get('risk_score') or 0),
+        c['domain'],
+    ))
+
+    # RESOLVED alone is not worth waking anyone up for
+    actionable = counts[NEW] + counts[ESCALATED] + counts[ACTIVATED] + counts[CHANGED]
+
+    return {
+        'counts': counts,
+        'changes': changes,
+        'first_runs': first_runs,
+        'total_changes': len(changes),
+        'actionable': actionable,
+        'has_alerts': actionable > 0,
+    }

--- a/src/state.py
+++ b/src/state.py
@@ -8,6 +8,10 @@ with new registrations, newly activated sites, and escalating risk instead of
 restating the steady state.
 """
 
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
 import json
 import logging
 import time

--- a/src/typo_sniper.py
+++ b/src/typo_sniper.py
@@ -16,6 +16,7 @@ import argparse
 import asyncio
 import logging
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -29,8 +30,10 @@ load_dotenv()
 from cache import Cache  # noqa: E402
 from config import Config  # noqa: E402
 from exporters import CSVExporter, ExcelExporter, HTMLExporter, JSONExporter  # noqa: E402
+from notifiers import dispatch, write_delta_json  # noqa: E402
 from scanner import DomainScanner  # noqa: E402
-from utils import setup_logging, validate_domain  # noqa: E402
+from state import ScanHistory, summarize  # noqa: E402
+from utils import parse_interval, setup_logging, validate_domain  # noqa: E402
 from version import __version__  # noqa: E402
 
 console = Console()
@@ -51,6 +54,9 @@ class TypoSniper:
         self.cache = Cache(config.cache_dir)
         self.scanner = DomainScanner(config, self.cache)
         self.results = []
+
+        self.history = ScanHistory(config.state_dir, config.history_retain)
+        self.deltas: list = []
 
     def close(self) -> None:
         """Release the scanner's worker threads."""
@@ -128,9 +134,26 @@ class TypoSniper:
             try:
                 result = await self.scanner.scan_domain(domain)
                 self.results.append(result)
+
+                # Diff against the previous scan before recording this one,
+                # otherwise the new scan becomes its own baseline.
+                if self.config.enable_diff:
+                    delta = self.history.diff(result)
+                    self.deltas.append(delta)
+                    result['delta'] = delta
+                    self.history.record(result)
                 
                 if result['permutations']:
                     console.print(f"[green]✓[/green] Found {len(result['permutations'])} registered permutations")
+                    delta = result.get('delta')
+                    if delta and not delta.get('first_run'):
+                        counts = delta.get('counts', {})
+                        notable = counts.get('new', 0) + counts.get('escalated', 0) + counts.get('activated', 0)
+                        if notable:
+                            console.print(
+                                f"[bold yellow]  ↳ {notable} notable change(s) "
+                                f"since {delta.get('baseline')}[/bold yellow]"
+                            )
                 else:
                     console.print("[yellow]○[/yellow] No registered permutations found")
                 
@@ -238,6 +261,100 @@ class TypoSniper:
             )
 
 
+    def print_changes(self) -> dict:
+        """
+        Print what changed since the previous scan.
+
+        Returns:
+            The aggregate delta summary
+        """
+        from rich.table import Table
+
+        summary = summarize(self.deltas)
+
+        if summary.get('first_runs'):
+            console.print(
+                f"\n[dim]Baseline established for "
+                f"{len(summary['first_runs'])} domain(s); "
+                f"changes will be reported from the next scan.[/dim]"
+            )
+
+        if not summary['changes']:
+            if not summary.get('first_runs'):
+                console.print("\n[green]No changes since the previous scan.[/green]")
+            return summary
+
+        table = Table(
+            title="Changes Since Last Scan",
+            show_header=True,
+            header_style="bold magenta",
+        )
+        table.add_column("Change", width=10)
+        table.add_column("Domain", style="cyan", width=32)
+        table.add_column("Risk", justify="right", width=5)
+        table.add_column("Detail")
+
+        styles = {
+            'new': 'bold red',
+            'escalated': 'bold yellow',
+            'activated': 'yellow',
+            'changed': 'blue',
+            'resolved': 'green',
+        }
+
+        for change in summary['changes'][:40]:
+            style = styles.get(change['kind'], '')
+            score = change.get('risk_score')
+            table.add_row(
+                f"[{style}]{change['kind'].upper()}[/{style}]" if style else change['kind'],
+                change['domain'],
+                str(score) if isinstance(score, (int, float)) else '-',
+                str(change.get('detail', '')),
+            )
+
+        console.print("\n")
+        console.print(table)
+
+        if summary['total_changes'] > 40:
+            console.print(f"[dim]…and {summary['total_changes'] - 40} more.[/dim]")
+
+        return summary
+
+    async def notify(self, summary: dict) -> None:
+        """
+        Deliver the delta summary through configured alert channels.
+
+        Args:
+            summary: Aggregate delta summary
+        """
+        if not self.config.enable_notifications:
+            return
+
+        import aiohttp
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=self.config.notify_timeout + 10)
+            async with aiohttp.ClientSession(
+                timeout=timeout,
+                headers={'User-Agent': self.config.user_agent},
+            ) as session:
+                results = await dispatch(summary, self.config, session)
+
+            for channel, ok in results.items():
+                if ok:
+                    console.print(f"[green]✓[/green] Alert sent via {channel}")
+                else:
+                    console.print(f"[red]✗[/red] Alert failed via {channel}")
+        except Exception as e:
+            self.logger.error(f"Notification dispatch failed: {e}", exc_info=True)
+            console.print(f"[red]✗[/red] Notification dispatch failed: {e}")
+
+    def reset(self) -> None:
+        """Clear per-scan results so the instance can run again in watch mode."""
+        self.results = []
+        self.deltas = []
+
+
 def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -247,6 +364,9 @@ def parse_arguments() -> argparse.Namespace:
 Examples:
   # Scan domains from file with default settings
   python typo_sniper.py -i domains.txt
+
+  # Monitor continuously and alert Slack when something changes
+  python typo_sniper.py -i domains.txt --watch --interval 6h --notify slack
 
   # Filter domains registered in the last 3 months
   python typo_sniper.py -i domains.txt --months 3
@@ -330,12 +450,96 @@ Examples:
     )
 
     parser.add_argument(
+        '--watch',
+        action='store_true',
+        help='Run continuously, rescanning on an interval (see --interval)'
+    )
+
+    parser.add_argument(
+        '--interval',
+        type=str,
+        default=None,
+        help='Interval between scans in watch mode, e.g. 6h, 30m, 86400 (default: 24h)'
+    )
+
+    parser.add_argument(
+        '--no-diff',
+        action='store_true',
+        help='Disable change detection against previous scans'
+    )
+
+    parser.add_argument(
+        '--notify',
+        nargs='+',
+        choices=['slack', 'discord', 'webhook', 'email'],
+        default=None,
+        help='Alert channels to notify when changes are detected'
+    )
+
+    parser.add_argument(
+        '--notify-min-changes',
+        type=int,
+        default=None,
+        help='Only alert when at least this many changes are detected (default: 1)'
+    )
+
+    parser.add_argument(
+        '--no-rdap',
+        action='store_true',
+        help='Skip RDAP and use WHOIS only for registration data'
+    )
+
+    parser.add_argument(
         '--version',
         action='version',
         version=f'Typo Sniper v{__version__}'
     )
 
     return parser.parse_args()
+
+
+async def run_scan(sniper, domains, args, config) -> None:
+    """
+    Run one full scan cycle: scan, diff, report, export, alert.
+
+    Args:
+        sniper: TypoSniper instance
+        domains: Domains to scan
+        args: Parsed CLI arguments
+        config: Configuration object
+    """
+    sniper.reset()
+
+    console.print()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        console=console
+    ) as progress:
+        await sniper.scan_domains(domains, progress)
+
+    sniper.print_summary()
+
+    summary = None
+    if config.enable_diff:
+        summary = sniper.print_changes()
+
+    console.print("\n[bold]Exporting results...[/bold]")
+    sniper.export_results(args.format, args.output)
+
+    if summary is not None:
+        try:
+            output_dir = Path(args.output).resolve()
+            output_dir.mkdir(parents=True, exist_ok=True)
+            delta_path = output_dir / 'latest_changes.json'
+            write_delta_json(summary, delta_path)
+            console.print(f"[green]✓[/green] Change summary written to {delta_path}")
+        except OSError as e:
+            sniper.logger.warning(f"Could not write change summary: {e}")
+
+        await sniper.notify(summary)
 
 
 async def main():
@@ -352,21 +556,31 @@ async def main():
     else:
         log_level = logging.WARNING
         debug_mode = False
-    
+
     setup_logging(log_level)
     logger = logging.getLogger(__name__)
 
     # Load configuration
     config = Config.from_file(args.config) if args.config else Config()
-    
+
     # Override config with command-line arguments
     config.max_workers = args.max_workers
     config.cache_ttl = args.cache_ttl
     config.use_cache = not args.no_cache
     config.months_filter = args.months
-    
-    # Store debug mode in config for access by other modules
     config.debug_mode = debug_mode
+
+    if args.no_diff:
+        config.enable_diff = False
+    if args.no_rdap:
+        config.use_rdap = False
+    if args.notify:
+        config.notify_channels = list(args.notify)
+        config.enable_notifications = True
+    if args.notify_min_changes is not None:
+        config.notify_min_changes = args.notify_min_changes
+    if args.interval:
+        config.watch_interval = parse_interval(args.interval, config.watch_interval)
 
     # Display banner
     console.print("\n[bold cyan]" + "=" * 60 + "[/bold cyan]")
@@ -375,47 +589,62 @@ async def main():
     )
     console.print("[bold cyan]" + "=" * 60 + "[/bold cyan]\n")
 
-    # Initialize Typo Sniper
     sniper = TypoSniper(config)
 
     exit_code = 0
     try:
-        # Load domains
         domains = sniper.load_domains(args.input)
-        
+
         if not domains:
             console.print("[red]No valid domains found in input file![/red]")
+            sniper.close()
             sys.exit(1)
 
         console.print(f"[bold]Domains to scan:[/bold] {len(domains)}")
         console.print(f"[bold]Output formats:[/bold] {', '.join(args.format)}")
         console.print(f"[bold]Cache enabled:[/bold] {'Yes' if config.use_cache else 'No'}")
-        
+        console.print(
+            f"[bold]Registration lookup:[/bold] "
+            f"{'RDAP (WHOIS fallback)' if config.use_rdap else 'WHOIS only'}"
+        )
+        console.print(
+            f"[bold]Change detection:[/bold] {'On' if config.enable_diff else 'Off'}"
+        )
+        if config.enable_notifications:
+            console.print(
+                f"[bold]Alerts:[/bold] {', '.join(config.notify_channels) or 'none configured'}"
+            )
         if args.months > 0:
-            console.print(f"[bold]Filter:[/bold] Domains registered in last {args.months} months")
+            console.print(
+                f"[bold]Filter:[/bold] Domains registered in last {args.months} months"
+            )
 
-        # Scan domains with progress bar
-        console.print()
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TaskProgressColumn(),
-            console=console
-        ) as progress:
-            await sniper.scan_domains(domains, progress)
+        if args.watch:
+            interval = config.watch_interval
+            console.print(
+                f"[bold]Watch mode:[/bold] rescanning every "
+                f"{interval}s ({interval // 3600}h {(interval % 3600) // 60}m). "
+                f"Press Ctrl+C to stop.\n"
+            )
 
-        # Print summary
-        sniper.print_summary()
-
-        # Export results
-        console.print("\n[bold]Exporting results...[/bold]")
-        sniper.export_results(args.format, args.output)
-
-        console.print("\n[bold green]✓ Scan completed successfully![/bold green]\n")
+            cycle = 0
+            while True:
+                cycle += 1
+                console.print(
+                    f"[bold cyan]── Scan #{cycle} — "
+                    f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ──[/bold cyan]"
+                )
+                await run_scan(sniper, domains, args, config)
+                console.print(
+                    f"\n[dim]Sleeping {interval}s until the next scan…[/dim]\n"
+                )
+                await asyncio.sleep(interval)
+        else:
+            await run_scan(sniper, domains, args, config)
+            console.print("\n[bold green]✓ Scan completed successfully![/bold green]\n")
 
     except KeyboardInterrupt:
-        console.print("\n[yellow]Scan interrupted by user[/yellow]")
+        console.print("\n[yellow]Interrupted by user[/yellow]")
         exit_code = 130
     except Exception as e:
         logger.error(f"Fatal error: {e}", exc_info=True)

--- a/src/utils.py
+++ b/src/utils.py
@@ -267,3 +267,40 @@ def safe_url(url: Any) -> str | None:
         return url
 
     return None
+
+
+def parse_interval(value: str, default: int = 86400) -> int:
+    """
+    Parse a human-friendly interval into seconds.
+
+    Accepts a bare number of seconds or a suffixed value such as "30m", "6h",
+    or "2d", so that watch mode reads naturally on the command line.
+
+    Args:
+        value: Interval string
+        default: Value to return when parsing fails
+
+    Returns:
+        Interval in seconds (minimum 60)
+    """
+    if value is None:
+        return default
+
+    text = str(value).strip().lower()
+    if not text:
+        return default
+
+    units = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400, 'w': 604800}
+    multiplier = 1
+
+    if text[-1] in units:
+        multiplier = units[text[-1]]
+        text = text[:-1]
+
+    try:
+        seconds = int(float(text) * multiplier)
+    except ValueError:
+        return default
+
+    # A scan takes minutes; anything under a minute is a misconfiguration
+    return max(60, seconds)

--- a/src/version.py
+++ b/src/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,41 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch, request):
+    """
+    Fail any test that opens a real network connection.
+
+    The suite is meant to run offline and deterministically. Without this
+    guard a test can silently start depending on the network: four pipeline
+    tests passed locally only because the sandbox blocked RDAP, forcing the
+    WHOIS fallback their stubs covered, and then failed on CI where RDAP
+    actually resolved. A test that behaves differently depending on what the
+    network allows is not testing anything reliable.
+
+    Loopback stays permitted so a test can stand up a local listener.
+    Mark a test with @pytest.mark.allow_network to opt out.
+    """
+    if request.node.get_closest_marker('allow_network'):
+        return
+
+    import socket
+
+    real_connect = socket.socket.connect
+
+    def guarded_connect(self, address, *args, **kwargs):
+        host = address[0] if isinstance(address, tuple) else address
+        if isinstance(host, str) and host not in ('127.0.0.1', '::1', 'localhost'):
+            raise AssertionError(
+                f"Test attempted a real network connection to {host}. "
+                f"Stub the client instead, or mark the test with "
+                f"@pytest.mark.allow_network."
+            )
+        return real_connect(self, address, *args, **kwargs)
+
+    monkeypatch.setattr(socket.socket, 'connect', guarded_connect)
+
+
 @pytest.fixture
 def config(tmp_path):
     """A Config pointed at a temporary cache directory."""

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -1,0 +1,364 @@
+"""Tests for alert formatting, gating, and delivery."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notifiers import (
+    DiscordNotifier,
+    EmailNotifier,
+    SlackNotifier,
+    WebhookNotifier,
+    _plain,
+    build_headline,
+    build_lines,
+    dispatch,
+)
+from state import ACTIVATED, CHANGED, ESCALATED, NEW, RESOLVED
+
+
+def summary(changes=None, counts=None, actionable=None):
+    changes = changes or []
+    counts = counts or {NEW: 0, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}
+    computed = counts[NEW] + counts[ESCALATED] + counts[ACTIVATED] + counts[CHANGED]
+    return {
+        'counts': counts,
+        'changes': changes,
+        'first_runs': [],
+        'total_changes': len(changes),
+        'actionable': computed if actionable is None else actionable,
+        'has_alerts': (computed if actionable is None else actionable) > 0,
+    }
+
+
+HOSTILE_CHANGE = {
+    'kind': NEW,
+    'domain': 'evil`*_~|<>[].com',
+    'risk_score': 90,
+    'detail': 'newly detected <script>alert(1)</script>',
+    'monitored_domain': 'brand.com',
+}
+
+
+def make_session(status=200, body=''):
+    response = MagicMock()
+    response.status = status
+    response.text = AsyncMock(return_value=body)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=response)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post = MagicMock(return_value=ctx)
+    return session
+
+
+class TestPlainText:
+    def test_strips_markup_significant_characters(self):
+        """Chat clients would otherwise render attacker-chosen formatting."""
+        cleaned = _plain('a`b*c_d~e|f<g>h[i]j')
+        for ch in '`*_~|<>[]':
+            assert ch not in cleaned
+
+    def test_strips_control_characters(self):
+        assert '\x00' not in _plain('bad\x00value')
+        assert '\n' not in _plain('two\nlines')
+
+    def test_truncates(self):
+        assert len(_plain('x' * 500, limit=50)) == 50
+
+    def test_handles_none(self):
+        assert _plain(None) == ''
+
+
+class TestFormatting:
+    def test_headline_lists_counts(self):
+        text = build_headline(summary(counts={
+            NEW: 2, ESCALATED: 1, ACTIVATED: 0, CHANGED: 0, RESOLVED: 4
+        }))
+        assert '2 new' in text
+        assert '1 escalated' in text
+        # Resolved is not alert-worthy and stays out of the headline
+        assert 'resolved' not in text
+
+    def test_headline_when_nothing_changed(self):
+        assert build_headline(summary()) == 'no changes'
+
+    def test_lines_include_domain_and_detail(self):
+        lines = build_lines(summary(changes=[{
+            'kind': NEW, 'domain': 'evil.com', 'risk_score': 80,
+            'detail': 'registered 2d ago',
+        }]))
+        assert 'evil.com' in lines[0]
+        assert 'risk 80' in lines[0]
+        assert 'registered 2d ago' in lines[0]
+
+    def test_lines_sanitise_untrusted_content(self):
+        lines = build_lines(summary(changes=[HOSTILE_CHANGE]))
+        assert '<script>' not in lines[0]
+        assert '`' not in lines[0]
+
+    def test_long_change_lists_are_truncated(self):
+        changes = [
+            {'kind': NEW, 'domain': f'd{i}.com', 'risk_score': 10, 'detail': 'x'}
+            for i in range(40)
+        ]
+        lines = build_lines(summary(changes=changes))
+        assert len(lines) == 26  # 25 items plus the "and N more" line
+        assert 'more change' in lines[-1]
+
+
+class TestSlackNotifier:
+    @pytest.mark.asyncio
+    async def test_posts_blocks(self, config):
+        config.slack_webhook_url = 'https://hooks.slack.test/abc'
+        session = make_session()
+
+        assert await SlackNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE], counts={
+                NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            session,
+        ) is True
+
+        payload = session.post.call_args.kwargs['json']
+        assert 'blocks' in payload
+        assert '<script>' not in str(payload)
+
+    @pytest.mark.asyncio
+    async def test_without_url_does_nothing(self, config):
+        config.slack_webhook_url = None
+        assert await SlackNotifier(config).send(summary(), make_session()) is False
+
+    @pytest.mark.asyncio
+    async def test_http_error_reported_as_failure(self, config):
+        config.slack_webhook_url = 'https://hooks.slack.test/abc'
+        assert await SlackNotifier(config).send(
+            summary(), make_session(status=500, body='boom')
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_network_error_reported_as_failure(self, config):
+        config.slack_webhook_url = 'https://hooks.slack.test/abc'
+        session = MagicMock()
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=OSError('unreachable'))
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session.post = MagicMock(return_value=ctx)
+        assert await SlackNotifier(config).send(summary(), session) is False
+
+
+class TestDiscordNotifier:
+    @pytest.mark.asyncio
+    async def test_posts_embed(self, config):
+        config.discord_webhook_url = 'https://discord.test/api/webhooks/1/x'
+        session = make_session()
+
+        assert await DiscordNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            session,
+        ) is True
+
+        embed = session.post.call_args.kwargs['json']['embeds'][0]
+        assert 'Typo Sniper' in embed['title']
+        assert isinstance(embed['color'], int)
+
+    @pytest.mark.asyncio
+    async def test_colour_reflects_most_severe_change(self, config):
+        config.discord_webhook_url = 'https://discord.test/api/webhooks/1/x'
+        session = make_session()
+        await DiscordNotifier(config).send(
+            summary(changes=[{'kind': NEW, 'domain': 'a.com', 'detail': 'x'}],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            session,
+        )
+        assert session.post.call_args.kwargs['json']['embeds'][0]['color'] == 0xD73A49
+
+
+class TestWebhookNotifier:
+    @pytest.mark.asyncio
+    async def test_posts_structured_payload(self, config):
+        config.webhook_url = 'https://example.test/hook'
+        session = make_session()
+
+        assert await WebhookNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            session,
+        ) is True
+
+        payload = session.post.call_args.kwargs['json']
+        assert payload['source'] == 'typo-sniper'
+        assert payload['changes'][0]['monitored_domain'] == 'brand.com'
+
+    @pytest.mark.asyncio
+    async def test_auth_header_is_applied(self, config):
+        config.webhook_url = 'https://example.test/hook'
+        config.webhook_auth_header = 'Authorization: Bearer abc:123'
+        session = make_session()
+
+        await WebhookNotifier(config).send(summary(), session)
+        headers = session.post.call_args.kwargs['headers']
+        # Split once, so a token containing ':' survives
+        assert headers['Authorization'] == 'Bearer abc:123'
+
+    @pytest.mark.asyncio
+    async def test_malformed_auth_header_is_ignored(self, config):
+        config.webhook_url = 'https://example.test/hook'
+        config.webhook_auth_header = 'no-colon-here'
+        session = make_session()
+        await WebhookNotifier(config).send(summary(), session)
+        assert session.post.call_args.kwargs['headers'] == {}
+
+
+class TestEmailNotifier:
+    @pytest.mark.asyncio
+    async def test_without_config_does_nothing(self, config):
+        config.smtp_host = None
+        assert await EmailNotifier(config).send(summary(), MagicMock()) is False
+
+    def test_message_escapes_untrusted_html(self, config, monkeypatch):
+        config.smtp_host = 'smtp.test'
+        config.email_to = 'soc@example.com'
+        config.email_from = 'sniper@example.com'
+
+        captured = {}
+
+        class FakeSMTP:
+            def __init__(self, *a, **k):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def starttls(self):
+                pass
+
+            def login(self, *a):
+                pass
+
+            def send_message(self, msg):
+                captured['msg'] = msg
+
+        monkeypatch.setattr('smtplib.SMTP', FakeSMTP)
+
+        assert EmailNotifier(config)._send_sync(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0})
+        ) is True
+
+        body = str(captured['msg'])
+        assert '<script>alert(1)</script>' not in body
+
+    def test_smtp_failure_is_reported(self, config, monkeypatch):
+        config.smtp_host = 'smtp.test'
+        config.email_to = 'soc@example.com'
+        monkeypatch.setattr(
+            'smtplib.SMTP',
+            MagicMock(side_effect=OSError('connection refused')),
+        )
+        assert EmailNotifier(config)._send_sync(summary()) is False
+
+
+class TestDispatchGating:
+    @pytest.mark.asyncio
+    async def test_disabled_sends_nothing(self, config):
+        config.enable_notifications = False
+        config.notify_channels = ['slack']
+        assert await dispatch(summary(), config, make_session()) == {}
+
+    @pytest.mark.asyncio
+    async def test_no_changes_sends_nothing(self, config):
+        """The whole point is alerting on deltas, not on steady state."""
+        config.enable_notifications = True
+        config.notify_channels = ['slack']
+        config.slack_webhook_url = 'https://hooks.slack.test/x'
+        assert await dispatch(summary(), config, make_session()) == {}
+
+    @pytest.mark.asyncio
+    async def test_min_changes_threshold_is_respected(self, config):
+        config.enable_notifications = True
+        config.notify_channels = ['slack']
+        config.slack_webhook_url = 'https://hooks.slack.test/x'
+        config.notify_min_changes = 5
+
+        result = await dispatch(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            config, make_session(),
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_sends_when_threshold_met(self, config):
+        config.enable_notifications = True
+        config.notify_channels = ['slack']
+        config.slack_webhook_url = 'https://hooks.slack.test/x'
+        config.notify_min_changes = 1
+
+        result = await dispatch(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            config, make_session(),
+        )
+        assert result == {'slack': True}
+
+    @pytest.mark.asyncio
+    async def test_unknown_channel_is_skipped(self, config):
+        config.enable_notifications = True
+        config.notify_channels = ['carrier-pigeon']
+        result = await dispatch(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            config, make_session(),
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_notify_on_no_changes_opt_in(self, config):
+        config.enable_notifications = True
+        config.notify_channels = ['slack']
+        config.slack_webhook_url = 'https://hooks.slack.test/x'
+        config.notify_on_no_changes = True
+        config.notify_min_changes = 0
+
+        assert await dispatch(summary(), config, make_session()) == {'slack': True}
+
+
+class TestSanitisationBoundary:
+    """Chat channels render markup; machine consumers need exact values."""
+
+    @pytest.mark.asyncio
+    async def test_chat_channels_neutralise_markup(self, config):
+        config.slack_webhook_url = 'https://hooks.slack.test/x'
+        config.discord_webhook_url = 'https://discord.test/x'
+
+        for notifier_cls in (SlackNotifier, DiscordNotifier):
+            session = make_session()
+            await notifier_cls(config).send(
+                summary(changes=[HOSTILE_CHANGE],
+                        counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0,
+                                CHANGED: 0, RESOLVED: 0}),
+                session,
+            )
+            body = str(session.post.call_args.kwargs['json'])
+            assert '<script>' not in body
+            assert '`' not in body
+
+    @pytest.mark.asyncio
+    async def test_json_webhook_preserves_the_exact_domain(self, config):
+        """A SIEM correlates on the domain; a mangled value would be wrong."""
+        config.webhook_url = 'https://example.test/hook'
+        session = make_session()
+
+        await WebhookNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE],
+                    counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0,
+                            CHANGED: 0, RESOLVED: 0}),
+            session,
+        )
+
+        payload = session.post.call_args.kwargs['json']
+        assert payload['changes'][0]['domain'] == HOSTILE_CHANGE['domain']

--- a/tests/unit/test_rdap.py
+++ b/tests/unit/test_rdap.py
@@ -1,0 +1,296 @@
+"""Tests for the RDAP client and response parsing.
+
+Fixtures mirror real registry responses (RFC 7483 domain objects, RFC 7095
+jCards). Live RDAP endpoints are not contacted.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rdap import RDAPClient
+
+# A representative registry response: Verisign/PIR-style domain object
+DOMAIN_RESPONSE = {
+    "objectClassName": "domain",
+    "ldhName": "eff.org",
+    "status": ["client transfer prohibited", "server delete prohibited"],
+    "events": [
+        {"eventAction": "registration", "eventDate": "1990-10-10T04:00:00Z"},
+        {"eventAction": "expiration", "eventDate": "2030-10-09T04:00:00Z"},
+        {"eventAction": "last changed", "eventDate": "2025-09-08T18:22:11Z"},
+    ],
+    "entities": [
+        {
+            "roles": ["registrar"],
+            "publicIds": [{"type": "IANA Registrar ID", "identifier": "292"}],
+            "vcardArray": [
+                "vcard",
+                [
+                    ["version", {}, "text", "4.0"],
+                    ["fn", {}, "text", "MarkMonitor Inc."],
+                ],
+            ],
+            "entities": [
+                {
+                    "roles": ["abuse"],
+                    "vcardArray": [
+                        "vcard",
+                        [
+                            ["version", {}, "text", "4.0"],
+                            ["email", {}, "text", "abuse@markmonitor.com"],
+                        ],
+                    ],
+                }
+            ],
+        },
+        {
+            "roles": ["registrant"],
+            "vcardArray": [
+                "vcard",
+                [
+                    ["version", {}, "text", "4.0"],
+                    ["fn", {}, "text", "Jane Doe"],
+                    ["org", {}, "text", "Electronic Frontier Foundation"],
+                    ["email", {}, "text", "hostmaster@eff.org"],
+                    [
+                        "adr",
+                        {},
+                        "text",
+                        ["", "", "815 Eddy St", "San Francisco", "CA", "94109", "US"],
+                    ],
+                ],
+            ],
+        },
+    ],
+    "nameservers": [
+        {"ldhName": "NS1.EFF.ORG"},
+        {"ldhName": "NS2.EFF.ORG."},
+    ],
+}
+
+BOOTSTRAP_RESPONSE = {
+    "version": "1.0",
+    "services": [
+        [["com", "net"], ["https://rdap.verisign.com/com/v1/"]],
+        [["org"], ["https://rdap.publicinterestregistry.org/rdap/"]],
+        [["co.uk"], ["https://rdap.nominet.uk/uk/"]],
+        # Some entries list http before https; https must win
+        [["dev"], ["http://rdap.example/", "https://rdap.example/"]],
+    ],
+}
+
+
+class FakeResponse:
+    def __init__(self, status=200, payload=None):
+        self.status = status
+        self._payload = payload
+        self.headers = {'Content-Type': 'application/rdap+json'}
+
+    async def json(self, content_type=None):
+        if self._payload is None:
+            raise ValueError('no json')
+        return self._payload
+
+    async def text(self):
+        return ''
+
+
+def make_session(response):
+    """Build a mock aiohttp session whose GET yields `response`."""
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=response)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.get = MagicMock(return_value=ctx)
+    return session
+
+
+@pytest.fixture
+def client(config):
+    return RDAPClient(make_session(FakeResponse(payload=BOOTSTRAP_RESPONSE)), config)
+
+
+class TestParseDomainResponse:
+    @pytest.fixture
+    def parsed(self):
+        return RDAPClient.parse(DOMAIN_RESPONSE)
+
+    def test_extracts_registration_dates(self, parsed):
+        assert parsed['whois_created'] == ['1990-10-10']
+        assert parsed['whois_expires'] == ['2030-10-09']
+        assert parsed['whois_updated'] == ['2025-09-08']
+
+    def test_extracts_registrar(self, parsed):
+        assert parsed['whois_registrar'] == 'MarkMonitor Inc.'
+
+    def test_extracts_registrant_and_org(self, parsed):
+        assert parsed['whois_registrant'] == 'Jane Doe'
+        assert parsed['whois_org'] == 'Electronic Frontier Foundation'
+
+    def test_extracts_country_from_jcard_address(self, parsed):
+        assert parsed['whois_country'] == 'US'
+
+    def test_collects_emails_including_nested_abuse_contact(self, parsed):
+        assert 'hostmaster@eff.org' in parsed['whois_emails']
+        assert 'abuse@markmonitor.com' in parsed['whois_emails']
+
+    def test_normalises_nameservers(self, parsed):
+        """Lowercased with the root trailing dot removed."""
+        assert parsed['whois_name_servers'] == ['ns1.eff.org', 'ns2.eff.org']
+
+    def test_records_its_source(self, parsed):
+        """Reports must be able to say where registration data came from."""
+        assert parsed['registration_source'] == 'rdap'
+
+    def test_preserves_status_codes(self, parsed):
+        assert 'client transfer prohibited' in parsed['whois_status']
+
+    def test_output_matches_the_whois_key_shape(self, parsed):
+        """Exporters and scoring must not care which source answered."""
+        for key in (
+            'whois_created', 'whois_updated', 'whois_expires', 'whois_registrant',
+            'whois_org', 'whois_registrar', 'whois_emails', 'whois_name_servers',
+            'whois_status', 'whois_country',
+        ):
+            assert key in parsed
+
+
+class TestParseEdgeCases:
+    def test_empty_response(self):
+        parsed = RDAPClient.parse({})
+        assert parsed['whois_created'] == []
+        assert parsed['whois_registrar'] is None
+
+    def test_missing_vcard(self):
+        parsed = RDAPClient.parse({'entities': [{'roles': ['registrar']}]})
+        assert parsed['whois_registrar'] is None
+
+    def test_registrar_falls_back_to_iana_id(self):
+        parsed = RDAPClient.parse({
+            'entities': [{
+                'roles': ['registrar'],
+                'publicIds': [{'identifier': '292'}],
+            }]
+        })
+        assert parsed['whois_registrar'] == 'IANA 292'
+
+    def test_malformed_events_are_skipped(self):
+        parsed = RDAPClient.parse({
+            'events': [
+                'not a dict',
+                {'eventAction': 'registration'},
+                {'eventDate': '2020-01-01T00:00:00Z'},
+                {'eventAction': 'registration', 'eventDate': 'not-a-date'},
+                {'eventAction': 'registration', 'eventDate': '2020-01-01T00:00:00Z'},
+            ]
+        })
+        assert parsed['whois_created'] == ['2020-01-01']
+
+    def test_status_string_is_wrapped(self):
+        parsed = RDAPClient.parse({'status': 'active'})
+        assert parsed['whois_status'] == ['active']
+
+    def test_org_given_as_list(self):
+        parsed = RDAPClient.parse({
+            'entities': [{
+                'roles': ['registrant'],
+                'vcardArray': ['vcard', [['org', {}, 'text', ['Acme', 'Security']]]],
+            }]
+        })
+        assert parsed['whois_org'] == 'Acme Security'
+
+    @pytest.mark.parametrize('value,expected', [
+        ('2024-03-05T12:00:00Z', '2024-03-05'),
+        ('2024-03-05T12:00:00+00:00', '2024-03-05'),
+        ('2024-03-05', '2024-03-05'),
+        ('garbage', None),
+        (None, None),
+        (12345, None),
+    ])
+    def test_timestamp_parsing(self, value, expected):
+        assert RDAPClient._parse_timestamp(value) == expected
+
+    def test_timezone_is_normalised_to_utc(self):
+        """A late-evening local time must not roll the date backwards."""
+        assert RDAPClient._parse_timestamp('2024-03-05T23:30:00-05:00') == '2024-03-06'
+
+
+class TestBootstrap:
+    @pytest.mark.asyncio
+    async def test_indexes_tlds(self, client):
+        mapping = await client._load_bootstrap()
+        assert mapping['com'] == 'https://rdap.verisign.com/com/v1/'
+        assert mapping['org'] == 'https://rdap.publicinterestregistry.org/rdap/'
+
+    @pytest.mark.asyncio
+    async def test_prefers_https_endpoints(self, client):
+        mapping = await client._load_bootstrap()
+        assert mapping['dev'].startswith('https://')
+
+    @pytest.mark.asyncio
+    async def test_is_fetched_only_once(self, client):
+        await client._load_bootstrap()
+        await client._load_bootstrap()
+        assert client.session.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_endpoint_resolution(self, client):
+        assert await client.endpoint_for('example.com') == 'https://rdap.verisign.com/com/v1/'
+        assert await client.endpoint_for('sub.example.org') is not None
+
+    @pytest.mark.asyncio
+    async def test_multi_label_suffix_wins_over_bare_tld(self, client):
+        """co.uk must route to Nominet, not to a generic .uk service."""
+        assert await client.endpoint_for('example.co.uk') == 'https://rdap.nominet.uk/uk/'
+
+    @pytest.mark.asyncio
+    async def test_unknown_tld_has_no_endpoint(self, client):
+        assert await client.endpoint_for('example.invalidtld') is None
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_failure_degrades_quietly(self, config):
+        """A blocked or failing IANA fetch must not break the scan."""
+        client = RDAPClient(make_session(FakeResponse(status=403)), config)
+        mapping = await client._load_bootstrap()
+        # Falls back to the hardcoded extras rather than raising
+        assert isinstance(mapping, dict)
+        assert await client.endpoint_for('example.com') is None
+
+
+class TestLookup:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_data(self, config):
+        client = RDAPClient(make_session(FakeResponse(payload=BOOTSTRAP_RESPONSE)), config)
+        await client._load_bootstrap()
+        client.session = make_session(FakeResponse(payload=DOMAIN_RESPONSE))
+
+        result = await client.lookup('eff.org')
+        assert result['whois_created'] == ['1990-10-10']
+
+    @pytest.mark.asyncio
+    async def test_404_means_unregistered(self, config):
+        client = RDAPClient(make_session(FakeResponse(payload=BOOTSTRAP_RESPONSE)), config)
+        await client._load_bootstrap()
+        client.session = make_session(FakeResponse(status=404))
+
+        assert await client.lookup('nonexistent.com') is None
+
+    @pytest.mark.asyncio
+    async def test_no_endpoint_returns_none(self, config):
+        client = RDAPClient(make_session(FakeResponse(payload=BOOTSTRAP_RESPONSE)), config)
+        assert await client.lookup('example.invalidtld') is None
+
+    @pytest.mark.asyncio
+    async def test_network_failure_returns_none(self, config):
+        client = RDAPClient(make_session(FakeResponse(payload=BOOTSTRAP_RESPONSE)), config)
+        await client._load_bootstrap()
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=OSError('connection refused'))
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.get = MagicMock(return_value=ctx)
+        client.session = session
+
+        assert await client.lookup('eff.org') is None

--- a/tests/unit/test_scan_pipeline.py
+++ b/tests/unit/test_scan_pipeline.py
@@ -39,6 +39,15 @@ def scanner(config, tmp_path, monkeypatch):
     s = DomainScanner(config, Cache(tmp_path / 'cache'))
     monkeypatch.setattr(s, '_run_dnstwist', lambda domain: copy.deepcopy(DNSTWIST_OUTPUT))
     monkeypatch.setattr(s, '_whois_lookup', lambda domain: dict(WHOIS_DATA.get(domain, {})))
+
+    # Exercise the WHOIS path deterministically. Leaving RDAP live made these
+    # tests depend on whether the environment could reach real registries:
+    # they passed where RDAP was blocked and failed where it resolved.
+    async def no_rdap(perms):
+        return {p['domain'] for p in perms}
+
+    monkeypatch.setattr(s, '_enrich_with_rdap', no_rdap)
+
     yield s
     s.close()
 
@@ -124,3 +133,91 @@ class TestScanDomain:
         scanner.config.use_cache = True
         await scanner.scan_domain('example.com')
         assert scanner.cache.get('whois:exampe.com') == WHOIS_DATA['exampe.com']
+
+
+class TestRegistrationSourceSelection:
+    """RDAP is tried first; WHOIS covers registries that publish no endpoint."""
+
+    @pytest.fixture
+    def scanner(self, config, tmp_path, monkeypatch):
+        s = DomainScanner(config, Cache(tmp_path / 'cache'))
+        monkeypatch.setattr(s, '_run_dnstwist',
+                            lambda domain: copy.deepcopy(DNSTWIST_OUTPUT))
+        yield s
+        s.close()
+
+    @pytest.mark.asyncio
+    async def test_rdap_success_skips_whois(self, scanner, monkeypatch):
+        whois_calls = []
+
+        async def rdap_resolves_all(perms):
+            for p in perms:
+                p.update({'whois_created': [RECENT], 'registration_source': 'rdap'})
+                scanner.lookup_sources['rdap'] += 1
+                scanner.whois_succeeded += 1
+            return set()
+
+        monkeypatch.setattr(scanner, '_enrich_with_rdap', rdap_resolves_all)
+        monkeypatch.setattr(scanner, '_whois_lookup',
+                            lambda d: whois_calls.append(d) or {})
+
+        result = await scanner.scan_domain('example.com')
+
+        assert whois_calls == []
+        assert result['lookup_sources']['rdap'] == 2
+        assert all(p['registration_source'] == 'rdap'
+                   for p in result['permutations'])
+
+    @pytest.mark.asyncio
+    async def test_whois_covers_what_rdap_cannot(self, scanner, monkeypatch):
+        async def rdap_resolves_one(perms):
+            perms[0].update({'whois_created': [RECENT], 'registration_source': 'rdap'})
+            scanner.lookup_sources['rdap'] += 1
+            scanner.whois_succeeded += 1
+            return {p['domain'] for p in perms[1:]}
+
+        monkeypatch.setattr(scanner, '_enrich_with_rdap', rdap_resolves_one)
+        monkeypatch.setattr(
+            scanner, '_whois_lookup',
+            lambda d: {'whois_created': [OLD], 'whois_registrar': 'Fallback Registrar'},
+        )
+
+        result = await scanner.scan_domain('example.com')
+        sources = {p['domain']: p.get('registration_source')
+                   for p in result['permutations']}
+
+        assert 'rdap' in sources.values()
+        assert 'whois' in sources.values()
+
+    @pytest.mark.asyncio
+    async def test_fallback_can_be_disabled(self, scanner, monkeypatch):
+        """--no-whois-fallback must not silently fall through."""
+        scanner.config.whois_fallback = False
+        whois_calls = []
+
+        async def rdap_resolves_nothing(perms):
+            return {p['domain'] for p in perms}
+
+        monkeypatch.setattr(scanner, '_enrich_with_rdap', rdap_resolves_nothing)
+        monkeypatch.setattr(scanner, '_whois_lookup',
+                            lambda d: whois_calls.append(d) or {})
+
+        await scanner.scan_domain('example.com')
+        assert whois_calls == []
+
+    @pytest.mark.asyncio
+    async def test_rdap_disabled_uses_whois_only(self, scanner, monkeypatch):
+        scanner.config.use_rdap = False
+        rdap_calls = []
+
+        async def should_not_run(perms):
+            rdap_calls.append(perms)
+            return set()
+
+        monkeypatch.setattr(scanner, '_enrich_with_rdap', should_not_run)
+        monkeypatch.setattr(scanner, '_whois_lookup',
+                            lambda d: {'whois_created': [OLD]})
+
+        result = await scanner.scan_domain('example.com')
+        assert rdap_calls == []
+        assert result['lookup_sources']['whois'] == 2

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,0 +1,229 @@
+"""Tests for scan history persistence and change detection."""
+
+import pytest
+
+from state import ACTIVATED, CHANGED, ESCALATED, NEW, RESOLVED, ScanHistory, summarize
+
+
+def perm(domain, **kwargs):
+    """Build a permutation with sensible defaults."""
+    base = {
+        'domain': domain,
+        'fuzzer': 'homoglyph',
+        'risk_score': 20,
+        'created_days_ago': 500,
+        'dns_a': ['203.0.113.1'],
+        'threat_intel': {},
+    }
+    threat = kwargs.pop('threat_intel', None)
+    base.update(kwargs)
+    if threat is not None:
+        base['threat_intel'] = threat
+    return base
+
+
+def result(domain='example.com', permutations=None, scan_date='2026-01-01'):
+    perms = permutations or []
+    return {
+        'original_domain': domain,
+        'scan_date': scan_date,
+        'total_permutations': len(perms),
+        'registered_count': len(perms),
+        'filtered_count': len(perms),
+        'permutations': perms,
+    }
+
+
+@pytest.fixture
+def history(tmp_path):
+    return ScanHistory(tmp_path / 'state', retain=5)
+
+
+class TestPersistence:
+    def test_first_load_is_empty(self, history):
+        assert history.load('example.com') == []
+
+    def test_record_then_load(self, history):
+        history.record(result(permutations=[perm('exampe.com')]))
+        scans = history.load('example.com')
+        assert len(scans) == 1
+        assert 'exampe.com' in scans[0]['permutations']
+
+    def test_newest_scan_is_first(self, history):
+        history.record(result(scan_date='2026-01-01'))
+        history.record(result(scan_date='2026-01-02'))
+        assert history.load('example.com')[0]['scan_date'] == '2026-01-02'
+
+    def test_retention_limit_is_enforced(self, history):
+        for i in range(10):
+            history.record(result(scan_date=f'2026-01-{i + 1:02d}'))
+        assert len(history.load('example.com')) == 5
+
+    def test_domains_are_isolated(self, history):
+        history.record(result('a.com', [perm('a1.com')]))
+        history.record(result('b.com', [perm('b1.com')]))
+        assert 'a1.com' in history.load('a.com')[0]['permutations']
+        assert 'b1.com' in history.load('b.com')[0]['permutations']
+
+    def test_corrupt_history_degrades_to_empty(self, history):
+        history.record(result())
+        corrupted = next((history.state_dir).glob('*.json'))
+        corrupted.write_text('{not json')
+        assert history.load('example.com') == []
+
+    def test_result_without_domain_is_ignored(self, history):
+        history.record({'permutations': []})
+        assert list(history.state_dir.glob('*.json')) == []
+
+
+class TestFirstRun:
+    def test_no_baseline_reports_no_changes(self, history):
+        """Reporting 70 domains as 'new' on day one would be noise."""
+        delta = history.diff(result(permutations=[perm(f'x{i}.com') for i in range(5)]))
+        assert delta['first_run'] is True
+        assert delta['changes'] == []
+        assert delta['total_current'] == 5
+
+
+class TestChangeDetection:
+    def _seed(self, history, permutations):
+        history.record(result(permutations=permutations))
+
+    def test_new_domain_detected(self, history):
+        self._seed(history, [perm('old.com')])
+        delta = history.diff(result(permutations=[perm('old.com'), perm('brandnew.com')]))
+        news = [c for c in delta['changes'] if c['kind'] == NEW]
+        assert [c['domain'] for c in news] == ['brandnew.com']
+
+    def test_new_domain_detail_mentions_signals(self, history):
+        self._seed(history, [])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', created_days_ago=3, dns_mx=['mx.evil.com'],
+                 threat_intel={'http_probe': {'https_active': True}})
+        ]))
+        detail = delta['changes'][0]['detail']
+        assert 'registered 3d ago' in detail
+        assert 'has MX' in detail
+        assert 'serving HTTPS' in detail
+
+    def test_parked_domain_going_live_is_activation(self, history):
+        self._seed(history, [perm('evil.com', threat_intel={})])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', threat_intel={'http_probe': {'https_active': True}})
+        ]))
+        kinds = [(c['kind'], c['detail']) for c in delta['changes']]
+        assert (ACTIVATED, 'started serving content') in kinds
+
+    def test_added_mx_is_activation(self, history):
+        self._seed(history, [perm('evil.com')])
+        delta = history.diff(result(permutations=[perm('evil.com', dns_mx=['mx.evil.com'])]))
+        assert any('mail servers' in c['detail'] for c in delta['changes'])
+
+    def test_new_certificate_is_activation(self, history):
+        self._seed(history, [perm('evil.com')])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', threat_intel={'certificate_transparency': {'certificates_found': 2}})
+        ]))
+        assert any('certificate' in c['detail'] for c in delta['changes'])
+
+    def test_urlscan_malicious_verdict_is_escalation(self, history):
+        self._seed(history, [perm('evil.com')])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', threat_intel={'urlscan': {'malicious': True}})
+        ]))
+        assert any(c['kind'] == ESCALATED and 'URLScan' in c['detail']
+                   for c in delta['changes'])
+
+    def test_risk_jump_is_escalation(self, history):
+        self._seed(history, [perm('evil.com', risk_score=20)])
+        delta = history.diff(result(permutations=[perm('evil.com', risk_score=65)]))
+        assert any(c['kind'] == ESCALATED and '20 -> 65' in c['detail']
+                   for c in delta['changes'])
+
+    def test_small_risk_drift_is_not_reported(self, history):
+        """A few points of noise should not page anyone."""
+        self._seed(history, [perm('evil.com', risk_score=20)])
+        delta = history.diff(result(permutations=[perm('evil.com', risk_score=25)]))
+        assert not any(c['kind'] == ESCALATED for c in delta['changes'])
+
+    def test_registrar_change_detected(self, history):
+        self._seed(history, [perm('evil.com', whois_registrar='OldReg')])
+        delta = history.diff(result(permutations=[perm('evil.com', whois_registrar='NewReg')]))
+        assert any(c['kind'] == CHANGED and 'registrar' in c['detail']
+                   for c in delta['changes'])
+
+    def test_ip_change_detected(self, history):
+        self._seed(history, [perm('evil.com', dns_a=['1.1.1.1'])])
+        delta = history.diff(result(permutations=[perm('evil.com', dns_a=['2.2.2.2'])]))
+        assert any('IP changed' in c['detail'] for c in delta['changes'])
+
+    def test_disappeared_domain_is_resolved(self, history):
+        self._seed(history, [perm('gone.com'), perm('stays.com')])
+        delta = history.diff(result(permutations=[perm('stays.com')]))
+        assert any(c['kind'] == RESOLVED and c['domain'] == 'gone.com'
+                   for c in delta['changes'])
+
+    def test_steady_state_produces_no_changes(self, history):
+        perms = [perm('a.com'), perm('b.com')]
+        self._seed(history, perms)
+        delta = history.diff(result(permutations=perms))
+        assert delta['changes'] == []
+
+    def test_changes_are_ordered_by_severity_then_risk(self, history):
+        self._seed(history, [perm('drift.com', whois_registrar='Old'), perm('old.com')])
+        delta = history.diff(result(permutations=[
+            perm('drift.com', whois_registrar='New'),
+            perm('old.com'),
+            perm('fresh.com', risk_score=90),
+        ]))
+        assert delta['changes'][0]['kind'] == NEW
+
+    def test_counts_reflect_changes(self, history):
+        self._seed(history, [perm('gone.com')])
+        delta = history.diff(result(permutations=[perm('added.com')]))
+        assert delta['counts'][NEW] == 1
+        assert delta['counts'][RESOLVED] == 1
+
+
+class TestSummarize:
+    def test_aggregates_across_domains(self):
+        summary = summarize([
+            {'domain': 'a.com', 'first_run': False,
+             'counts': {NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0},
+             'changes': [{'kind': NEW, 'domain': 'x.com', 'risk_score': 50}]},
+            {'domain': 'b.com', 'first_run': False,
+             'counts': {NEW: 0, ESCALATED: 1, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0},
+             'changes': [{'kind': ESCALATED, 'domain': 'y.com', 'risk_score': 70}]},
+        ])
+        assert summary['counts'][NEW] == 1
+        assert summary['counts'][ESCALATED] == 1
+        assert summary['total_changes'] == 2
+        assert summary['has_alerts'] is True
+
+    def test_tags_changes_with_their_monitored_domain(self):
+        summary = summarize([
+            {'domain': 'brand.com', 'first_run': False,
+             'counts': {NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0},
+             'changes': [{'kind': NEW, 'domain': 'brnad.com', 'risk_score': 50}]},
+        ])
+        assert summary['changes'][0]['monitored_domain'] == 'brand.com'
+
+    def test_first_runs_are_listed_not_counted(self):
+        summary = summarize([{'domain': 'a.com', 'first_run': True, 'changes': []}])
+        assert summary['first_runs'] == ['a.com']
+        assert summary['has_alerts'] is False
+
+    def test_resolved_alone_does_not_alert(self):
+        """A squat going away is good news, not something to page on."""
+        summary = summarize([
+            {'domain': 'a.com', 'first_run': False,
+             'counts': {NEW: 0, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 3},
+             'changes': [{'kind': RESOLVED, 'domain': 'g.com', 'risk_score': 10}]},
+        ])
+        assert summary['has_alerts'] is False
+        assert summary['total_changes'] == 1
+
+    def test_empty_input(self):
+        summary = summarize([])
+        assert summary['total_changes'] == 0
+        assert summary['has_alerts'] is False


### PR DESCRIPTION
First of four planned releases. v1.1.0 made the data correct; this makes it worth reading on a schedule. Closes the core of #9 (alerting).

## Change detection — the reason for this PR

Every scan is now diffed against the previous one, and reports lead with what *moved*:

| Kind | Meaning |
|---|---|
| `NEW` | A lookalike that wasn't registered at the last scan |
| `ESCALATED` | Risk score jumped ≥10, or URLScan flagged it malicious |
| `ACTIVATED` | Parked domain started serving content, gained MX records, or obtained a certificate |
| `CHANGED` | Registrar, registrant, org, or hosting IP changed |
| `RESOLVED` | Stopped resolving |

Someone reading a daily report wants the delta, not a restatement of seventy unchanged rows. The first scan of a domain establishes a baseline **silently** — reporting every known permutation as "new" on day one would be noise, and would train the reader to ignore the report.

`ACTIVATED` is the one I'd watch most: a parked squat that suddenly serves content and has MX records is the transition that precedes an actual campaign.

## RDAP replaces WHOIS as the primary lookup

WHOIS needs TCP/43, which is blocked on many corporate networks and in most CI sandboxes, where it fails as a *silent timeout* rather than a clear error. While developing v1.1.0, **every one of 67 lookups failed** for exactly this reason — that's what motivated the circuit breaker added there. Working around a broken transport was the wrong fix.

RDAP (RFC 7482) is HTTPS on 443, returns structured JSON with unambiguous timestamps instead of per-registry free text, and shares the scanner's existing async session rather than occupying a worker thread. WHOIS remains the fallback for registries publishing no RDAP endpoint, and results record which source answered.

## Alerting

Slack, Discord, a generic JSON webhook, and email — firing **only when a scan detects changes**. An alert that repeats the same seventy domains every morning gets muted within a week; *"a new lookalike appeared three days ago and it has MX records"* gets read. `notify_min_changes` suppresses trivial drift; endpoints come from the environment as secrets.

```bash
typo_sniper.py -i domains.txt --watch --interval 6h --notify slack
```

## Watch mode

`--watch --interval 6h` runs continuously. The compose file previously carried a "scheduled" service whose own comment admitted it needed `crond` to actually schedule anything.

## Security note

Chat notifiers strip markup-significant characters from domain names, registrant fields, and page titles — all attacker-controlled, the same class of issue fixed in the exporters in 1.1.0. The JSON webhook **deliberately** sends values verbatim: its consumer is a machine correlating on the exact domain, and mangling `g00gle<script>.com` would corrupt the primary key. JSON encoding already prevents structural injection. That boundary is asserted by tests in both directions.

---

## Verification

- **287 tests pass** (72% coverage, up from 69%), ruff clean, all Python 3.10–3.13
- **Change detection verified end to end** against a live scan with a tampered baseline — all five change kinds fire and sort by severity
- **Alert delivery verified over a real HTTP round-trip** to a local listener across Slack, Discord, and webhook payloads

**Not verified live:** RDAP against real registries. The sandbox proxy `connect_rejected`s `data.iana.org` and every registry endpoint — the same block that affects crt.sh and port 43. Parsing and endpoint resolution are covered by 33 tests built from real RFC 7483 response fixtures, and the no-endpoint path was observed degrading cleanly to the WHOIS fallback. **Worth a manual smoke test on a normal network before merge.**

One bug the tests caught during development: the RDAP suffix-matching loop never tried the bare TLD, so `example.com` resolved no endpoint. Fixed and regression-tested.

## What's next

| PR | Scope |
|---|---|
| 2 | SPF/DMARC/DKIM, Public Suffix List, per-brand keywords (#4 groundwork) |
| 3 | Claude/OpenAI/Gemini/Ollama analysis + expanded secrets managers (#12, #5) |
| 4 | ML scoring on accumulated history, PyPI + GHCR release (#4, #11) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_