### PR TITLE
Add mail-capability intelligence and Public Suffix List (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-24
+
+Detection quality. Adds the single strongest pre-attack signal a lookalike can
+emit, and fixes registrable-domain splitting for most of the world.
+
+### Added
+
+- **Mail-capability intelligence (SPF / DKIM / DMARC).** Registering a lookalike
+  is cheap and means little. Provisioning it to send mail that passes receiver
+  checks is deliberate work whose only purpose is deliverable mail, which is the
+  prerequisite for credential phishing and business email compromise. Domains are
+  now classified `none` / `receive-only` / `partial` / `provisioned` / `hardened`,
+  reported in a new `Mail` column, and scored accordingly. A squat that gains
+  send capability between scans raises an `ESCALATED` change.
+- **Public Suffix List** for registrable-domain splitting, replacing the ~40-entry
+  hardcoded tuple added in 1.1.0. That list mishandled everything outside it:
+  `example.com.br` and `example.github.io` were split wrongly, so generated
+  variations pointed at the wrong namespace entirely. `publicsuffixlist` bundles
+  its data offline and is released on the PSL's own cadence.
+- **Per-brand combo-squatting keywords** (`custom_keywords`). Product names,
+  campaign names, and support portals are better bait than the generic list.
+  `replace_default_keywords` uses only your terms.
+
+### Fixed
+
+- **A failed DNS lookup is no longer reported as a finding.** Large TXT responses
+  need TCP, and the first implementation returned "no SPF" for any domain whose
+  response exceeded UDP limits — `google.com` among them. That is the same
+  mistake as treating a WHOIS timeout as "no registration date": absence of
+  evidence rendered as evidence of absence. Lookups now retry over TCP, and a
+  genuine failure yields `unknown`, which scores zero and is labelled
+  "Lookup failed" in reports rather than left blank.
+
+### Changed
+
+- Risk scoring uses the full mail assessment where available, replacing the
+  earlier MX-only heuristic. MX alone shows a domain can *receive*; SPF shows it
+  is provisioned to *send*.
+
 ## [1.2.0] - 2026-08-24
 
 Turns a report generator into a monitoring tool. Scans are now diffed against

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -93,6 +93,23 @@ urlscan_wait_timeout: 90           # Max seconds to wait for new scan results
 
 enable_certificate_transparency: true  # Enable CT log monitoring (no API key needed)
 
+# Mail-capability intelligence (SPF / DKIM / DMARC)
+# The strongest pre-attack signal a lookalike can emit. Registering a domain is
+# cheap; provisioning it to send mail that passes receiver checks is deliberate
+# work with one obvious purpose. A failed lookup is reported as "unknown" rather
+# than as "no mail capability".
+enable_mail_intel: true
+enable_dkim_probe: true            # One DNS query per selector probed
+dkim_selectors: []                 # empty = common defaults (google, selector1, k1, ...)
+dns_timeout: 5.0
+dns_nameservers: []                # empty = system resolvers
+
+# Combo-squatting keywords specific to your brand. Product names, campaign
+# names and support portals make far better bait than the generic list.
+#   custom_keywords: [vault, sso, partners, billing-portal]
+custom_keywords: []
+replace_default_keywords: false    # true = use only custom_keywords
+
 # HTTP probing
 enable_http_probe: true            # Probe domains with HTTP/HTTPS
 http_timeout: 10                   # HTTP request timeout (seconds)

--- a/docs/config.yaml.example
+++ b/docs/config.yaml.example
@@ -93,6 +93,23 @@ urlscan_wait_timeout: 90           # Max seconds to wait for new scan results
 
 enable_certificate_transparency: true  # Enable CT log monitoring (no API key needed)
 
+# Mail-capability intelligence (SPF / DKIM / DMARC)
+# The strongest pre-attack signal a lookalike can emit. Registering a domain is
+# cheap; provisioning it to send mail that passes receiver checks is deliberate
+# work with one obvious purpose. A failed lookup is reported as "unknown" rather
+# than as "no mail capability".
+enable_mail_intel: true
+enable_dkim_probe: true            # One DNS query per selector probed
+dkim_selectors: []                 # empty = common defaults (google, selector1, k1, ...)
+dns_timeout: 5.0
+dns_nameservers: []                # empty = system resolvers
+
+# Combo-squatting keywords specific to your brand. Product names, campaign
+# names and support portals make far better bait than the generic list.
+#   custom_keywords: [vault, sso, partners, billing-portal]
+custom_keywords: []
+replace_default_keywords: false    # true = use only custom_keywords
+
 # HTTP probing
 enable_http_probe: true            # Probe domains with HTTP/HTTPS
 http_timeout: 10                   # HTTP request timeout (seconds)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,11 @@ PyYAML==6.0.3
 # no-op, and more permutations come back as unresolvable error sentinels.
 dnspython==2.8.0
 
+# Public Suffix List for correct registrable-domain splitting. Bundles its data
+# offline (no network at runtime) and is released on the PSL's own cadence, so
+# newly delegated TLDs are handled without a code change. MPL-2.0.
+publicsuffixlist==1.0.2.20260821
+
 # Excel support
 openpyxl==3.1.5
 

--- a/src/config.py
+++ b/src/config.py
@@ -108,6 +108,20 @@ class Config:
     
     enable_certificate_transparency: bool = True  # No API key needed
     
+    # Mail-capability intelligence (SPF / DKIM / DMARC)
+    # A lookalike provisioned to send deliverable mail is set up for phishing,
+    # which is a materially different threat from a parked registration.
+    enable_mail_intel: bool = True
+    enable_dkim_probe: bool = True
+    dkim_selectors: list = field(default_factory=list)  # empty = common defaults
+    dns_timeout: float = 5.0
+    dns_nameservers: list = field(default_factory=list)  # empty = system resolvers
+
+    # Combo-squatting keywords specific to your brand. Product names, campaign
+    # names and support portals are far better bait than the generic list.
+    custom_keywords: list = field(default_factory=list)
+    replace_default_keywords: bool = False  # True = use only custom_keywords
+
     # HTTP probing
     enable_http_probe: bool = True
     http_timeout: int = 10

--- a/src/dns_intel.py
+++ b/src/dns_intel.py
@@ -1,0 +1,344 @@
+"""
+Mail-capability intelligence for lookalike domains.
+
+The strongest pre-attack signal a typosquat can emit is *mail provisioning*.
+Registering a lookalike costs a few dollars and means little on its own. Setting
+up SPF, DKIM and DMARC on it is deliberate work whose only purpose is to make
+mail from that domain arrive in inboxes rather than spam folders — which is the
+prerequisite for credential phishing and business email compromise, not for a
+parked domain someone is holding to resell.
+
+This module answers three questions per domain:
+
+  * Can it receive mail?  (MX, already collected by dnstwist)
+  * Is it provisioned to send mail that passes receiver checks?  (SPF, DKIM)
+  * Has the operator configured a DMARC policy?
+
+A lookalike with a full SPF/DKIM/DMARC stack is a materially different threat
+from one with an A record and nothing else.
+"""
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+# DKIM keys live at <selector>._domainkey.<domain> and the selector is not
+# discoverable from DNS. These cover the defaults used by the mail platforms an
+# attacker is most likely to sign up for.
+COMMON_DKIM_SELECTORS = (
+    'default',        # generic / self-hosted
+    'google',         # Google Workspace
+    'selector1',      # Microsoft 365
+    'selector2',      # Microsoft 365 (rotation pair)
+    'k1',             # Mailchimp / Mandrill
+    's1',             # SendGrid and others
+    'mail',           # common self-hosted convention
+    'dkim',           # common self-hosted convention
+    'zoho',           # Zoho Mail
+    'protonmail',     # Proton
+)
+
+SPF_PREFIX = 'v=spf1'
+DMARC_PREFIX = 'v=dmarc1'
+
+# SPF qualifier on the "all" mechanism, which says what to do with mail from
+# senders the record does not authorise
+_ALL_RE = re.compile(r'([~\-+?])all\b', re.IGNORECASE)
+_DMARC_POLICY_RE = re.compile(r'\bp\s*=\s*(none|quarantine|reject)\b', re.IGNORECASE)
+
+
+class DNSIntelligence:
+    """Query mail-related DNS records for a domain."""
+
+    def __init__(self, config):
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+        self._resolver = None
+
+    def _get_resolver(self):
+        """
+        Build a dnspython async resolver, or None when dnspython is absent.
+
+        Returns:
+            An async resolver, or None if DNS intelligence cannot run
+        """
+        if self._resolver is not None:
+            return self._resolver
+
+        try:
+            import dns.asyncresolver
+        except ImportError:
+            self.logger.warning(
+                "dnspython is not installed; SPF/DKIM/DMARC checks are unavailable"
+            )
+            return None
+
+        resolver = dns.asyncresolver.Resolver()
+        resolver.timeout = self.config.dns_timeout
+        resolver.lifetime = self.config.dns_timeout
+        if self.config.dns_nameservers:
+            resolver.nameservers = list(self.config.dns_nameservers)
+
+        self._resolver = resolver
+        return resolver
+
+    async def _query_txt(self, name: str) -> tuple[list[str], bool]:
+        """
+        Fetch TXT records for a name.
+
+        Args:
+            name: DNS name to query
+
+        Returns:
+            Tuple of (records, ok). ``ok`` is False when the lookup itself
+            failed, which is not the same as the name having no TXT records.
+            Conflating the two would report "no SPF" for a domain whose
+            response merely exceeded UDP limits — absence of evidence
+            rendered as evidence of absence.
+        """
+        resolver = self._get_resolver()
+        if resolver is None:
+            return [], False
+
+        import dns.resolver
+
+        # A large TXT response (many verification tokens) is truncated over
+        # UDP and must be retried over TCP.
+        for use_tcp in (False, True):
+            try:
+                answer = await resolver.resolve(name, 'TXT', tcp=use_tcp)
+                records = []
+                for rdata in answer:
+                    # TXT rdata is a sequence of <=255-byte strings that must be
+                    # concatenated; long DKIM keys always span several.
+                    parts = [
+                        p.decode('utf-8', 'replace') if isinstance(p, bytes) else str(p)
+                        for p in rdata.strings
+                    ]
+                    records.append(''.join(parts))
+                return records, True
+
+            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+                # Authoritative: the name genuinely has no TXT records
+                return [], True
+            except Exception as e:
+                if use_tcp:
+                    self.logger.debug(f"TXT lookup failed for {name}: {e}")
+                    return [], False
+
+        return [], False
+
+    # -- individual records ------------------------------------------------
+
+    async def check_spf(self, domain: str) -> dict[str, Any] | None:
+        """
+        Look for an SPF record.
+
+        Args:
+            domain: Domain to query
+
+        Returns:
+            SPF summary, ``{'unknown': True}`` when the lookup failed, or None
+            when the domain demonstrably has no SPF record
+        """
+        records, ok = await self._query_txt(domain)
+        if not ok:
+            return {'unknown': True}
+
+        for record in records:
+            if record.lower().startswith(SPF_PREFIX):
+                match = _ALL_RE.search(record)
+                qualifier = match.group(1) if match else None
+                return {
+                    'present': True,
+                    'record': record[:450],
+                    'all_qualifier': qualifier,
+                    'policy': {
+                        '-': 'fail', '~': 'softfail',
+                        '+': 'pass', '?': 'neutral',
+                    }.get(qualifier),
+                    # Third-party senders the domain authorises. A squat that
+                    # includes a bulk-mail provider is set up to send campaigns.
+                    'includes': re.findall(r'include:([^\s]+)', record)[:10],
+                }
+        return None
+
+    async def check_dmarc(self, domain: str) -> dict[str, Any] | None:
+        """
+        Look for a DMARC policy.
+
+        Args:
+            domain: Domain to query
+
+        Returns:
+            DMARC summary, ``{'unknown': True}`` when the lookup failed, or
+            None when the domain has no DMARC record
+        """
+        records, ok = await self._query_txt(f'_dmarc.{domain}')
+        if not ok:
+            return {'unknown': True}
+
+        for record in records:
+            if record.lower().startswith(DMARC_PREFIX):
+                match = _DMARC_POLICY_RE.search(record)
+                return {
+                    'present': True,
+                    'record': record[:450],
+                    'policy': match.group(1).lower() if match else None,
+                    # rua/ruf show where aggregate reports go, which sometimes
+                    # exposes the operator's real infrastructure
+                    'rua': re.findall(r'rua=([^;]+)', record)[:3],
+                }
+        return None
+
+    async def check_dkim(self, domain: str) -> dict[str, Any] | None:
+        """
+        Probe common DKIM selectors.
+
+        A negative result is weak evidence: the selector namespace is
+        unbounded, so an absent key only means none of the common selectors
+        matched, not that DKIM is unconfigured.
+
+        Args:
+            domain: Domain to query
+
+        Returns:
+            DKIM summary, or None when no common selector responded
+        """
+        if not self.config.enable_dkim_probe:
+            return None
+
+        selectors = list(self.config.dkim_selectors or COMMON_DKIM_SELECTORS)
+
+        async def probe(selector):
+            records, _ = await self._query_txt(f'{selector}._domainkey.{domain}')
+            for record in records:
+                lowered = record.lower()
+                if 'v=dkim1' in lowered or 'p=' in lowered:
+                    return selector
+            return None
+
+        results = await asyncio.gather(
+            *(probe(s) for s in selectors), return_exceptions=True
+        )
+        found = [r for r in results if isinstance(r, str)]
+
+        if not found:
+            return None
+
+        return {'present': True, 'selectors': found}
+
+    # -- aggregate ---------------------------------------------------------
+
+    async def analyze(self, domain: str, has_mx: bool = False) -> dict[str, Any]:
+        """
+        Assess a domain's mail-sending capability.
+
+        Args:
+            domain: Domain to assess
+            has_mx: Whether the domain already has known MX records
+
+        Returns:
+            Mail capability report
+        """
+        spf, dmarc, dkim = await asyncio.gather(
+            self.check_spf(domain),
+            self.check_dmarc(domain),
+            self.check_dkim(domain),
+            return_exceptions=True,
+        )
+
+        spf = spf if isinstance(spf, dict) else None
+        dmarc = dmarc if isinstance(dmarc, dict) else None
+        dkim = dkim if isinstance(dkim, dict) else None
+
+        # A lookup that failed tells us nothing. Reporting it as "no mail
+        # capability" would be the same mistake as treating a WHOIS timeout as
+        # "no registration date": a silent failure dressed up as a finding.
+        lookup_failed = any(
+            isinstance(x, dict) and x.get('unknown') for x in (spf, dmarc)
+        )
+
+        spf = None if (spf or {}).get('unknown') else spf
+        dmarc = None if (dmarc or {}).get('unknown') else dmarc
+
+        return {
+            'spf': spf,
+            'dmarc': dmarc,
+            'dkim': dkim,
+            'lookup_failed': lookup_failed,
+            'can_receive': bool(has_mx),
+            'can_send': None if lookup_failed else bool(spf),
+            'posture': (
+                'unknown' if lookup_failed
+                else classify_mail_posture(spf, dmarc, dkim, has_mx)
+            ),
+        }
+
+
+def classify_mail_posture(spf, dmarc, dkim, has_mx: bool) -> str:
+    """
+    Summarise what a domain's mail configuration says about intent.
+
+    Args:
+        spf: SPF summary or None
+        dmarc: DMARC summary or None
+        dkim: DKIM summary or None
+        has_mx: Whether MX records exist
+
+    Returns:
+        One of: none, receive-only, partial, provisioned, hardened
+    """
+    signals = sum(bool(x) for x in (spf, dmarc, dkim))
+
+    if not signals and not has_mx:
+        return 'none'
+    if not signals:
+        return 'receive-only'
+
+    # A full stack means someone did the work to make mail deliverable
+    if spf and dkim and dmarc:
+        policy = (dmarc or {}).get('policy')
+        return 'hardened' if policy in ('quarantine', 'reject') else 'provisioned'
+
+    if spf and (dkim or dmarc):
+        return 'provisioned'
+
+    return 'partial'
+
+
+def score_mail_capability(mail: dict[str, Any] | None) -> int:
+    """
+    Convert a mail capability report into risk points.
+
+    Weighting reflects effort and intent rather than record count. Publishing
+    SPF on a lookalike is a deliberate act with one obvious purpose; a full
+    signed-and-aligned stack is a mail operation, not a parked name.
+
+    Args:
+        mail: Mail capability report, or None
+
+    Returns:
+        Risk points to add (0-25)
+    """
+    if not mail or mail.get('posture') == 'unknown':
+        # No evidence either way: score it as though the check never ran,
+        # rather than rewarding a domain for a failed lookup.
+        return 0
+
+    posture = mail.get('posture')
+    base = {
+        'none': 0,
+        'receive-only': 3,
+        'partial': 8,
+        'provisioned': 18,
+        'hardened': 22,
+    }.get(posture, 0)
+
+    # Authorising a bulk-mail provider on a lookalike points at campaigns
+    spf = mail.get('spf') or {}
+    if spf.get('includes'):
+        base += 3
+
+    return min(base, 25)

--- a/src/dns_intel.py
+++ b/src/dns_intel.py
@@ -18,6 +18,10 @@ A lookalike with a full SPF/DKIM/DMARC stack is a materially different threat
 from one with an A record and nothing else.
 """
 
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
 import asyncio
 import logging
 import re

--- a/src/enhanced_detection.py
+++ b/src/enhanced_detection.py
@@ -33,40 +33,71 @@ class ComboSquattingDetector:
     # Underscores are not valid in hostnames, so they are not a separator here
     SEPARATORS = ['-', '']
 
-    # Public suffixes that need two labels to identify the registrable domain.
-    # Without this, "example.co.uk" yields brand="example", tld="uk" and every
-    # generated variation points at the wrong namespace.
-    MULTI_LABEL_SUFFIXES = (
-        'co.uk', 'org.uk', 'me.uk', 'ac.uk', 'gov.uk', 'net.uk', 'sch.uk',
-        'com.au', 'net.au', 'org.au', 'edu.au', 'gov.au', 'id.au',
-        'co.nz', 'net.nz', 'org.nz', 'govt.nz',
-        'co.za', 'org.za', 'net.za',
-        'co.jp', 'or.jp', 'ne.jp', 'ac.jp', 'go.jp',
-        'com.br', 'net.br', 'org.br', 'gov.br',
-        'com.cn', 'net.cn', 'org.cn', 'gov.cn',
-        'co.in', 'net.in', 'org.in', 'gov.in',
-        'com.mx', 'com.ar', 'com.sg', 'com.hk', 'com.tw', 'com.tr',
+    # Registrable-domain splitting uses the Public Suffix List. The previous
+    # hardcoded tuple covered perhaps forty suffixes out of several thousand,
+    # so anything outside it (example.com.br, example.github.io) was split
+    # wrongly and generated variations in the wrong namespace.
+    _psl = None
+    _psl_checked = False
+
+    # Fallback for the handful of suffixes that matter most, used only when
+    # publicsuffixlist is not installed
+    FALLBACK_SUFFIXES = (
+        'co.uk', 'org.uk', 'ac.uk', 'gov.uk',
+        'com.au', 'net.au', 'org.au',
+        'co.nz', 'co.za', 'co.jp', 'co.in',
+        'com.br', 'com.cn', 'com.mx', 'com.sg', 'com.tr',
     )
+
+    @classmethod
+    def _get_psl(cls):
+        """Load the Public Suffix List once, or None when unavailable."""
+        if cls._psl_checked:
+            return cls._psl
+
+        cls._psl_checked = True
+        try:
+            from publicsuffixlist import PublicSuffixList
+
+            cls._psl = PublicSuffixList()
+        except ImportError:
+            logger.warning(
+                "publicsuffixlist is not installed; falling back to a small "
+                "hardcoded suffix list. Multi-label domains outside it may be "
+                "split incorrectly."
+            )
+            cls._psl = None
+
+        return cls._psl
 
     @classmethod
     def split_domain(cls, domain: str):
         """
-        Split a domain into its registrable label and suffix.
+        Split a domain into its registrable label and public suffix.
 
         Args:
-            domain: Domain such as "example.co.uk"
+            domain: Domain such as "example.co.uk" or "example.github.io"
 
         Returns:
             Tuple of (brand, suffix), e.g. ("example", "co.uk")
         """
         domain = domain.strip().lower().rstrip('.')
-        parts = domain.split('.')
+        parts = [p for p in domain.split('.') if p]
 
         if len(parts) < 2:
-            return parts[0] if parts else domain, 'com'
+            return (parts[0] if parts else domain), 'com'
 
+        psl = cls._get_psl()
+        if psl is not None:
+            suffix = psl.publicsuffix(domain)
+            if suffix and suffix != domain:
+                remainder = domain[: -(len(suffix) + 1)].split('.')
+                if remainder and remainder[-1]:
+                    return remainder[-1], suffix
+
+        # Fallback: check the two-label suffixes we know about
         last_two = '.'.join(parts[-2:])
-        if len(parts) >= 3 and last_two in cls.MULTI_LABEL_SUFFIXES:
+        if len(parts) >= 3 and last_two in cls.FALLBACK_SUFFIXES:
             return parts[-3], last_two
 
         return parts[-2], parts[-1]
@@ -327,7 +358,15 @@ def generate_enhanced_permutations(domain: str, config) -> set[str]:
     
     # Combo-squatting
     if config.enable_combosquatting:
-        combos = ComboSquattingDetector.generate_combosquats(domain)
+        custom = list(getattr(config, 'custom_keywords', None) or [])
+        if custom and getattr(config, 'replace_default_keywords', False):
+            keywords = custom
+        elif custom:
+            # Brand-specific terms first: they are the likeliest bait
+            keywords = custom + ComboSquattingDetector.COMMON_KEYWORDS
+        else:
+            keywords = None
+        combos = ComboSquattingDetector.generate_combosquats(domain, keywords)
         enhanced.update(combos)
         if hasattr(config, 'debug_mode') and config.debug_mode:
             logger.debug(f"  Generated {len(combos)} combo-squatting variations")

--- a/src/exporters.py
+++ b/src/exporters.py
@@ -40,7 +40,22 @@ def format_threat_intel(perm: dict[str, Any]) -> dict[str, Any]:
     Returns:
         Dictionary with 'urlscan', 'urlscan_url', 'ct', and 'http' keys
     """
-    summary = {'urlscan': '', 'urlscan_url': None, 'ct': '', 'http': '', 'tls': ''}
+    summary = {'urlscan': '', 'urlscan_url': None, 'ct': '', 'http': '', 'tls': '',
+               'mail': ''}
+
+    # Mail capability lives beside threat_intel, not inside it
+    mail = perm.get('mail_intel') or {}
+    if mail:
+        posture = mail.get('posture')
+        labels = {
+            'none': '',
+            'receive-only': 'Receive only (MX)',
+            'partial': 'Partial',
+            'provisioned': 'SEND-CAPABLE',
+            'hardened': 'SEND-CAPABLE (DMARC enforced)',
+            'unknown': 'Lookup failed',
+        }
+        summary['mail'] = labels.get(posture, posture or '')
 
     threat_intel = perm.get('threat_intel') or {}
     if not threat_intel:
@@ -233,7 +248,7 @@ class ExcelExporter(BaseExporter):
         # Headers
         headers = [
             "Scan Date", "Original Domain", "Permutation", "Fuzzer Type",
-            "Risk Score", "Age (days)", "URLScan Status", "CT Logs", "HTTP Status", "TLS",
+            "Risk Score", "Age (days)", "Mail", "URLScan Status", "CT Logs", "HTTP Status", "TLS",
             "Created Date", "Updated Date", "Expires Date",
             "Registrant", "Organization", "Registrar",
             "Email", "Country", "Status",
@@ -282,6 +297,7 @@ class ExcelExporter(BaseExporter):
                     perm.get('fuzzer', ''),
                     risk_score,
                     perm.get('created_days_ago', ''),
+                    intel['mail'],
                     urlscan_status,
                     intel['ct'],
                     intel['http'],
@@ -437,7 +453,7 @@ class CSVExporter(BaseExporter):
             # Write headers
             headers = [
                 'Scan Date', 'Original Domain', 'Permutation', 'Fuzzer Type',
-                'Risk Score', 'Age (days)', 'URLScan Status', 'URLScan Report',
+                'Risk Score', 'Age (days)', 'Mail', 'URLScan Status', 'URLScan Report',
                 'CT Logs', 'HTTP Status', 'TLS',
                 'Created Date', 'Updated Date', 'Expires Date',
                 'Registrant', 'Organization', 'Registrar',
@@ -461,6 +477,7 @@ class CSVExporter(BaseExporter):
                         perm.get('fuzzer', ''),
                         perm.get('risk_score', ''),
                         perm.get('created_days_ago', ''),
+                        intel['mail'],
                         intel['urlscan'],
                         intel['urlscan_url'] or '',
                         intel['ct'],
@@ -679,6 +696,7 @@ class HTMLExporter(BaseExporter):
                         <th>Fuzzer</th>
                         <th>Risk</th>
                         <th>Age (days)</th>
+                        <th>Mail</th>
                         <th>URLScan Status</th>
                         <th>CT Logs</th>
                         <th>HTTP Status</th>
@@ -727,6 +745,7 @@ class HTMLExporter(BaseExporter):
                         <td><span class="fuzzer-badge">{html.escape(str(perm.get('fuzzer', '')))}</span></td>
                         <td>{html.escape(str(perm.get('risk_score', '')))}</td>
                         <td>{age_cell}</td>
+                        <td>{html.escape(intel['mail'])}</td>
                         <td>{urlscan_cell}</td>
                         <td>{html.escape(intel['ct'])}</td>
                         <td>{html.escape(intel['http'])}</td>

--- a/src/scanner.py
+++ b/src/scanner.py
@@ -22,6 +22,7 @@ import whois
 
 from cache import Cache
 from config import Config
+from dns_intel import DNSIntelligence
 from enhanced_detection import SoundAlikeDetector, generate_enhanced_permutations
 from rdap import RDAPClient
 from threat_intelligence import ThreatIntelligence, calculate_risk_score
@@ -148,6 +149,11 @@ class DomainScanner:
 
         # Add threat intelligence
         enriched = await self._add_threat_intelligence(enriched)
+
+        # Mail capability: whether a lookalike is provisioned to send
+        # deliverable mail, which is the clearest pre-phishing signal
+        if self.config.enable_mail_intel:
+            await self._add_mail_intelligence(enriched)
 
         # Apply date filters if configured
         if self.config.months_filter > 0:
@@ -466,6 +472,46 @@ class DomainScanner:
                     perm['threat_intel'] = threat_data
         
         return permutations
+
+    async def _add_mail_intelligence(self, permutations: list[dict[str, Any]]) -> None:
+        """
+        Annotate permutations with SPF / DKIM / DMARC findings.
+
+        Args:
+            permutations: Permutation dictionaries, updated in place
+        """
+        if not permutations:
+            return
+
+        intel = DNSIntelligence(self.config)
+        if intel._get_resolver() is None:
+            return
+
+        semaphore = asyncio.Semaphore(max(1, self.config.max_workers))
+
+        async def one(perm):
+            async with semaphore:
+                return await intel.analyze(
+                    perm['domain'], has_mx=bool(perm.get('dns_mx'))
+                )
+
+        results = await asyncio.gather(
+            *(one(p) for p in permutations), return_exceptions=True
+        )
+
+        provisioned = 0
+        for perm, mail in zip(permutations, results, strict=False):
+            if isinstance(mail, Exception):
+                self.logger.debug(f"Mail intel failed for {perm['domain']}: {mail}")
+                continue
+            perm['mail_intel'] = mail
+            if mail.get('posture') in ('provisioned', 'hardened'):
+                provisioned += 1
+
+        if provisioned:
+            self.logger.info(
+                f"{provisioned} lookalike(s) are provisioned to send mail"
+            )
 
     async def _enrich_with_rdap(self, permutations: list[dict[str, Any]]) -> set:
         """

--- a/src/state.py
+++ b/src/state.py
@@ -144,6 +144,7 @@ class ScanHistory:
             'title': http.get('title'),
             'certificates_found': ct.get('certificates_found', 0),
             'urlscan_malicious': bool(urlscan.get('malicious')),
+            'mail_posture': (perm.get('mail_intel') or {}).get('posture'),
         }
 
     # -- diffing -----------------------------------------------------------
@@ -264,6 +265,40 @@ class ScanHistory:
                 'current': now,
             })
 
+        # Gaining the ability to send deliverable mail is the clearest
+        # pre-phishing transition this tool can observe.
+        rank = {'none': 0, 'receive-only': 1, 'partial': 2,
+                'provisioned': 3, 'hardened': 4}
+        # 'unknown' means the lookup failed, so there is nothing to compare
+        comparable = (before.get('mail_posture') != 'unknown'
+                      and now.get('mail_posture') != 'unknown')
+        old_mail = rank.get(before.get('mail_posture'), 0) if comparable else 0
+        new_mail = rank.get(now.get('mail_posture'), 0) if comparable else 0
+        if new_mail > old_mail and new_mail >= 3:
+            changes.append({
+                'kind': ESCALATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': (
+                    f"became provisioned to send mail "
+                    f"({before.get('mail_posture') or 'none'} -> "
+                    f"{now.get('mail_posture')})"
+                ),
+                'current': now,
+            })
+        elif new_mail > old_mail:
+            changes.append({
+                'kind': ACTIVATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': (
+                    f"mail configuration added "
+                    f"({before.get('mail_posture') or 'none'} -> "
+                    f"{now.get('mail_posture')})"
+                ),
+                'current': now,
+            })
+
         if now.get('urlscan_malicious') and not before.get('urlscan_malicious'):
             changes.append({
                 'kind': ESCALATED,
@@ -325,6 +360,8 @@ class ScanHistory:
             bits.append(f'registered {int(age)}d ago')
         if now.get('dns_mx'):
             bits.append('has MX')
+        if now.get('mail_posture') in ('provisioned', 'hardened'):
+            bits.append('SEND-CAPABLE mail')
         if now.get('https_active'):
             bits.append('serving HTTPS')
         elif now.get('http_active'):

--- a/src/threat_intelligence.py
+++ b/src/threat_intelligence.py
@@ -605,8 +605,15 @@ def calculate_risk_score(domain_data: dict[str, Any], threat_intel: dict[str, An
         score += 5
 
     # --- Mail capability ---------------------------------------------------
-    # A lookalike domain that can send and receive mail is set up for phishing
-    if domain_data.get('dns_mx'):
+    # Prefer the full SPF/DKIM/DMARC assessment when it ran: publishing SPF on
+    # a lookalike is deliberate work whose only purpose is deliverable mail.
+    # MX alone only shows the domain can receive.
+    mail = domain_data.get('mail_intel')
+    if mail:
+        from dns_intel import score_mail_capability
+
+        score += score_mail_capability(mail)
+    elif domain_data.get('dns_mx'):
         score += 15
 
     # --- Live content ------------------------------------------------------

--- a/src/version.py
+++ b/src/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/tests/unit/test_dns_intel.py
+++ b/tests/unit/test_dns_intel.py
@@ -1,0 +1,308 @@
+"""Tests for SPF / DKIM / DMARC assessment and mail-capability scoring."""
+
+
+import pytest
+
+from dns_intel import (
+    DNSIntelligence,
+    classify_mail_posture,
+    score_mail_capability,
+)
+
+SPF_BASIC = 'v=spf1 ip4:203.0.113.0/24 -all'
+SPF_WITH_PROVIDER = 'v=spf1 include:sendgrid.net include:_spf.google.com ~all'
+DMARC_REJECT = 'v=DMARC1; p=reject; rua=mailto:dmarc@evil.com'
+DMARC_NONE = 'v=DMARC1; p=none'
+DKIM_KEY = 'v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQ'
+
+
+@pytest.fixture
+def intel(config):
+    return DNSIntelligence(config)
+
+
+def stub_txt(intel, mapping, ok=True):
+    """
+    Make _query_txt answer from a name -> records mapping.
+
+    ``ok=False`` simulates a failed lookup, which must be distinguishable from
+    a domain that genuinely has no records.
+    """
+    async def fake(name):
+        return mapping.get(name, []), ok
+    intel._query_txt = fake
+    # Bypass the dnspython availability check
+    intel._resolver = object()
+    return intel
+
+
+class TestSPF:
+    @pytest.mark.asyncio
+    async def test_detects_spf(self, intel):
+        stub_txt(intel, {'evil.com': ['some other record', SPF_BASIC]})
+        result = await intel.check_spf('evil.com')
+        assert result['present'] is True
+        assert result['all_qualifier'] == '-'
+        assert result['policy'] == 'fail'
+
+    @pytest.mark.asyncio
+    async def test_extracts_third_party_senders(self, intel):
+        """An authorised bulk-mail provider points at campaign infrastructure."""
+        stub_txt(intel, {'evil.com': [SPF_WITH_PROVIDER]})
+        result = await intel.check_spf('evil.com')
+        assert 'sendgrid.net' in result['includes']
+        assert result['policy'] == 'softfail'
+
+    @pytest.mark.asyncio
+    async def test_absent_spf(self, intel):
+        stub_txt(intel, {'evil.com': ['google-site-verification=abc']})
+        assert await intel.check_spf('evil.com') is None
+
+    @pytest.mark.asyncio
+    async def test_no_records_at_all(self, intel):
+        stub_txt(intel, {})
+        assert await intel.check_spf('evil.com') is None
+
+
+class TestDMARC:
+    @pytest.mark.asyncio
+    async def test_detects_enforcing_policy(self, intel):
+        stub_txt(intel, {'_dmarc.evil.com': [DMARC_REJECT]})
+        result = await intel.check_dmarc('evil.com')
+        assert result['policy'] == 'reject'
+        assert result['rua'] == ['mailto:dmarc@evil.com']
+
+    @pytest.mark.asyncio
+    async def test_detects_monitoring_only_policy(self, intel):
+        stub_txt(intel, {'_dmarc.evil.com': [DMARC_NONE]})
+        assert (await intel.check_dmarc('evil.com'))['policy'] == 'none'
+
+    @pytest.mark.asyncio
+    async def test_queries_the_dmarc_subdomain(self, intel):
+        """DMARC lives at _dmarc.<domain>, not at the apex."""
+        stub_txt(intel, {'evil.com': [DMARC_REJECT]})
+        assert await intel.check_dmarc('evil.com') is None
+
+
+class TestDKIM:
+    @pytest.mark.asyncio
+    async def test_finds_common_selector(self, intel):
+        stub_txt(intel, {'google._domainkey.evil.com': [DKIM_KEY]})
+        result = await intel.check_dkim('evil.com')
+        assert result['selectors'] == ['google']
+
+    @pytest.mark.asyncio
+    async def test_finds_multiple_selectors(self, intel):
+        stub_txt(intel, {
+            'selector1._domainkey.evil.com': [DKIM_KEY],
+            'selector2._domainkey.evil.com': [DKIM_KEY],
+        })
+        assert set((await intel.check_dkim('evil.com'))['selectors']) == {
+            'selector1', 'selector2'
+        }
+
+    @pytest.mark.asyncio
+    async def test_absent_returns_none(self, intel):
+        stub_txt(intel, {})
+        assert await intel.check_dkim('evil.com') is None
+
+    @pytest.mark.asyncio
+    async def test_can_be_disabled(self, intel):
+        """DKIM probing costs one query per selector; it is opt-out."""
+        intel.config.enable_dkim_probe = False
+        stub_txt(intel, {'google._domainkey.evil.com': [DKIM_KEY]})
+        assert await intel.check_dkim('evil.com') is None
+
+    @pytest.mark.asyncio
+    async def test_custom_selectors_are_used(self, intel):
+        intel.config.dkim_selectors = ['corp2024']
+        stub_txt(intel, {'corp2024._domainkey.evil.com': [DKIM_KEY]})
+        assert (await intel.check_dkim('evil.com'))['selectors'] == ['corp2024']
+
+
+class TestPostureClassification:
+    @pytest.mark.parametrize('spf,dmarc,dkim,mx,expected', [
+        (None, None, None, False, 'none'),
+        (None, None, None, True, 'receive-only'),
+        ({'present': True}, None, None, False, 'partial'),
+        ({'present': True}, {'policy': 'none'}, None, False, 'provisioned'),
+        ({'present': True}, {'policy': 'none'}, {'present': True}, True, 'provisioned'),
+        ({'present': True}, {'policy': 'reject'}, {'present': True}, True, 'hardened'),
+        ({'present': True}, {'policy': 'quarantine'}, {'present': True}, True, 'hardened'),
+    ])
+    def test_classification(self, spf, dmarc, dkim, mx, expected):
+        assert classify_mail_posture(spf, dmarc, dkim, mx) == expected
+
+
+class TestMailScoring:
+    def test_no_data_scores_zero(self):
+        assert score_mail_capability(None) == 0
+        assert score_mail_capability({}) == 0
+
+    def test_scores_rise_with_provisioning(self):
+        scores = [
+            score_mail_capability({'posture': p})
+            for p in ('none', 'receive-only', 'partial', 'provisioned', 'hardened')
+        ]
+        assert scores == sorted(scores)
+        assert scores[0] == 0
+
+    def test_send_capable_outweighs_receive_only(self):
+        """Receiving mail is passive; sending it is the phishing prerequisite."""
+        assert (score_mail_capability({'posture': 'provisioned'})
+                > score_mail_capability({'posture': 'receive-only'}) * 3)
+
+    def test_bulk_sender_adds_points(self):
+        plain = score_mail_capability({'posture': 'provisioned'})
+        bulk = score_mail_capability({
+            'posture': 'provisioned', 'spf': {'includes': ['sendgrid.net']}
+        })
+        assert bulk > plain
+
+    def test_score_is_capped(self):
+        assert score_mail_capability({
+            'posture': 'hardened', 'spf': {'includes': ['a', 'b', 'c']}
+        }) <= 25
+
+
+class TestAnalyze:
+    @pytest.mark.asyncio
+    async def test_full_stack_is_hardened(self, intel):
+        stub_txt(intel, {
+            'evil.com': [SPF_WITH_PROVIDER],
+            '_dmarc.evil.com': [DMARC_REJECT],
+            'google._domainkey.evil.com': [DKIM_KEY],
+        })
+        report = await intel.analyze('evil.com', has_mx=True)
+        assert report['posture'] == 'hardened'
+        assert report['can_send'] is True
+        assert report['can_receive'] is True
+
+    @pytest.mark.asyncio
+    async def test_bare_domain_has_no_mail_capability(self, intel):
+        stub_txt(intel, {})
+        report = await intel.analyze('parked.com', has_mx=False)
+        assert report['posture'] == 'none'
+        assert report['can_send'] is False
+
+    @pytest.mark.asyncio
+    async def test_mx_without_spf_is_receive_only(self, intel):
+        stub_txt(intel, {})
+        report = await intel.analyze('evil.com', has_mx=True)
+        assert report['posture'] == 'receive-only'
+
+
+class TestResolverAvailability:
+    def test_missing_dnspython_degrades_quietly(self, config, monkeypatch):
+        """The scan must continue without DNS intelligence, not crash."""
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **k):
+            if name.startswith('dns.'):
+                raise ImportError('no dnspython')
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, '__import__', fake_import)
+        assert DNSIntelligence(config)._get_resolver() is None
+
+    @pytest.mark.asyncio
+    async def test_query_without_resolver_reports_failure(self, config, monkeypatch):
+        """No resolver is a failed lookup, not a domain with no records."""
+        intel = DNSIntelligence(config)
+        monkeypatch.setattr(intel, '_get_resolver', lambda: None)
+        assert await intel._query_txt('evil.com') == ([], False)
+
+
+class TestPublicSuffixSplitting:
+    """The PSL replaced a hardcoded list that covered ~40 of several thousand."""
+
+    @pytest.mark.parametrize('domain,expected', [
+        ('example.com', ('example', 'com')),
+        ('example.co.uk', ('example', 'co.uk')),
+        ('example.com.br', ('example', 'com.br')),
+        ('example.com.au', ('example', 'com.au')),
+        ('shop.example.org', ('example', 'org')),
+        # Private suffixes the old hardcoded tuple got wrong
+        ('example.github.io', ('example', 'github.io')),
+    ])
+    def test_split(self, domain, expected):
+        from enhanced_detection import ComboSquattingDetector
+
+        assert ComboSquattingDetector.split_domain(domain) == expected
+
+    def test_combosquats_stay_in_the_right_namespace(self):
+        from enhanced_detection import ComboSquattingDetector
+
+        variants = ComboSquattingDetector.generate_combosquats(
+            'example.com.br', ['login']
+        )
+        assert all(v.endswith('.com.br') for v in variants)
+
+
+class TestCustomKeywords:
+    def test_custom_keywords_are_included(self, config):
+        from enhanced_detection import generate_enhanced_permutations
+
+        config.enable_combosquatting = True
+        config.custom_keywords = ['vault']
+        result = generate_enhanced_permutations('acme.com', config)
+        assert 'acme-vault.com' in result
+        assert 'acme-login.com' in result  # defaults still present
+
+    def test_replace_mode_uses_only_custom_keywords(self, config):
+        from enhanced_detection import generate_enhanced_permutations
+
+        config.enable_combosquatting = True
+        config.custom_keywords = ['vault']
+        config.replace_default_keywords = True
+        result = generate_enhanced_permutations('acme.com', config)
+        assert 'acme-vault.com' in result
+        assert 'acme-login.com' not in result
+
+
+class TestLookupFailureIsNotAFinding:
+    """
+    A failed DNS lookup must never be reported as "no mail capability".
+
+    This is the same class of bug as treating a WHOIS timeout as "no
+    registration date": a silent failure dressed up as a finding. It surfaced
+    for real during development, where large TXT responses needing TCP were
+    reported as domains having no SPF at all.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failed_lookup_yields_unknown_posture(self, intel):
+        stub_txt(intel, {}, ok=False)
+        report = await intel.analyze('evil.com', has_mx=False)
+        assert report['posture'] == 'unknown'
+        assert report['lookup_failed'] is True
+        assert report['can_send'] is None  # not False
+
+    @pytest.mark.asyncio
+    async def test_successful_lookup_with_no_records_is_a_real_finding(self, intel):
+        stub_txt(intel, {}, ok=True)
+        report = await intel.analyze('parked.com', has_mx=False)
+        assert report['posture'] == 'none'
+        assert report['lookup_failed'] is False
+        assert report['can_send'] is False
+
+    @pytest.mark.asyncio
+    async def test_spf_check_signals_failure(self, intel):
+        stub_txt(intel, {}, ok=False)
+        assert (await intel.check_spf('evil.com')) == {'unknown': True}
+
+    @pytest.mark.asyncio
+    async def test_dmarc_check_signals_failure(self, intel):
+        stub_txt(intel, {}, ok=False)
+        assert (await intel.check_dmarc('evil.com')) == {'unknown': True}
+
+    def test_unknown_posture_scores_zero(self):
+        """Neither credit nor penalty for something we could not measure."""
+        assert score_mail_capability({'posture': 'unknown'}) == 0
+
+    def test_unknown_is_reported_not_left_blank(self):
+        from exporters import format_threat_intel
+
+        out = format_threat_intel({'mail_intel': {'posture': 'unknown'}})
+        assert out['mail'] == 'Lookup failed'

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -130,7 +130,8 @@ class TestJsonExporter:
 class TestFormatThreatIntel:
     def test_empty_intel(self):
         assert format_threat_intel({}) == {
-            'urlscan': '', 'urlscan_url': None, 'ct': '', 'http': '', 'tls': ''
+            'urlscan': '', 'urlscan_url': None, 'ct': '', 'http': '', 'tls': '',
+            'mail': '',
         }
 
     def test_urlscan_error_statuses(self):
@@ -158,6 +159,16 @@ class TestFormatThreatIntel:
         out = format_threat_intel({'threat_intel': {'http_probe': {
             'https_active': True, 'https_status': 200, 'tls_verified': verified}}})
         assert out['tls'] == expected
+
+    @pytest.mark.parametrize('posture,expected', [
+        ('provisioned', 'SEND-CAPABLE'),
+        ('hardened', 'SEND-CAPABLE (DMARC enforced)'),
+        ('receive-only', 'Receive only (MX)'),
+        ('none', ''),
+    ])
+    def test_reports_mail_posture(self, posture, expected):
+        out = format_threat_intel({'mail_intel': {'posture': posture}})
+        assert out['mail'] == expected
 
     def test_ct_certificate_count(self):
         out = format_threat_intel({'threat_intel': {

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -227,3 +227,48 @@ class TestSummarize:
         summary = summarize([])
         assert summary['total_changes'] == 0
         assert summary['has_alerts'] is False
+
+
+class TestMailPostureChanges:
+    """A squat gaining send-capable mail is the key pre-phishing transition."""
+
+    def _seed(self, history, permutations):
+        history.record(result(permutations=permutations))
+
+    def test_becoming_send_capable_is_an_escalation(self, history):
+        self._seed(history, [perm('evil.com', mail_intel={'posture': 'none'})])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', mail_intel={'posture': 'provisioned'})
+        ]))
+        assert any(c['kind'] == ESCALATED and 'provisioned to send mail' in c['detail']
+                   for c in delta['changes'])
+
+    def test_gaining_only_mx_is_a_lesser_activation(self, history):
+        self._seed(history, [perm('evil.com', mail_intel={'posture': 'none'})])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', mail_intel={'posture': 'receive-only'})
+        ]))
+        mail_changes = [c for c in delta['changes'] if 'mail configuration' in c['detail']]
+        assert mail_changes and mail_changes[0]['kind'] == ACTIVATED
+
+    def test_hardening_further_still_escalates(self, history):
+        self._seed(history, [perm('evil.com', mail_intel={'posture': 'provisioned'})])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', mail_intel={'posture': 'hardened'})
+        ]))
+        assert any(c['kind'] == ESCALATED for c in delta['changes'])
+
+    def test_losing_mail_capability_is_not_an_alert(self, history):
+        """Regression, not escalation — nothing to page on."""
+        self._seed(history, [perm('evil.com', mail_intel={'posture': 'hardened'})])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', mail_intel={'posture': 'none'})
+        ]))
+        assert not any(c['kind'] == ESCALATED for c in delta['changes'])
+
+    def test_new_send_capable_domain_says_so(self, history):
+        self._seed(history, [])
+        delta = history.diff(result(permutations=[
+            perm('evil.com', mail_intel={'posture': 'hardened'})
+        ]))
+        assert 'SEND-CAPABLE mail' in delta['changes'][0]['detail']


### PR DESCRIPTION
**Stacked on #24** — review that one first; this PR targets its branch so the diff stays clean. Groundwork for #4.

## Mail-capability intelligence — the point of this PR

Registering a lookalike costs a few dollars and means little on its own. Setting up **SPF, DKIM and DMARC** on it is deliberate work whose only purpose is making mail from that domain reach inboxes rather than spam folders — the prerequisite for credential phishing and BEC, and pointless for a parked name someone is holding to resell.

| Posture | Meaning | Risk |
|---|---|---|
| `none` | No mail configuration | +0 |
| `receive-only` | MX only — can receive, not send | +3 |
| `partial` | SPF but nothing else | +8 |
| `provisioned` | SPF + DKIM or DMARC — **set up to send** | +18 |
| `hardened` | Full stack, DMARC enforcing | +22 |

MX alone only shows a domain can *receive*; SPF shows it's provisioned to *send*. That's why the MX-only heuristic from v1.1.0 understated exactly the case that matters. A squat that gains send capability between scans now raises an **`ESCALATED`** change — the transition most worth waking someone up for.

Live verification: `eff.org` → `provisioned` (+21), a parked domain → `none` (+0).

## Public Suffix List

Replaces the ~40-entry hardcoded suffix tuple I added in v1.1.0. That was a stopgap and it mishandled everything outside itself:

| Domain | Old (wrong) | New |
|---|---|---|
| `example.com.br` | `('example.com', 'br')` | `('example', 'com.br')` |
| `example.github.io` | `('example', 'io')` | `('example', 'github.io')` |

Split wrongly means every generated variation pointed at the **wrong namespace entirely**. `publicsuffixlist` bundles its data offline (works on restricted networks), has zero hard dependencies, is MPL-2.0 (AGPL-compatible), and is released on the PSL's own cadence — newly delegated suffixes need no code change from you.

## Per-brand keywords

```yaml
custom_keywords: [vault, sso, partners, billing-portal]
replace_default_keywords: false
```

Product and campaign names are better bait than a generic wordlist.

---

## The bug worth reading about

My first implementation of this reported **"no SPF" for `google.com`** — caught only because I tested against live DNS rather than trusting the unit tests.

Large TXT responses (dozens of verification tokens) exceed UDP limits and need TCP. The lookup failed, and I returned "no records," which the classifier read as "no mail capability."

That's **the same mistake this project already fixed once**: treating a WHOIS timeout as "no registration date" in v1.1.0. Absence of evidence rendered as evidence of absence — and worse here, because the entire point of the feature is distinguishing provisioned domains from inert ones. A silent failure would systematically under-report the exact threat it exists to find.

Fixed properly: lookups retry over TCP, and a genuine failure yields `unknown`, which

- scores **zero** rather than crediting the domain for a failed check,
- is labelled **"Lookup failed"** in reports rather than left blank, and
- is **excluded from posture-change detection**, so it can't forge an escalation.

There's a dedicated test class (`TestLookupFailureIsNotAFinding`) asserting all three, because this is a mistake worth not making a third time.

---

## Verification

- **361 tests pass** (74% coverage, up from 72%), ruff clean
- SPF/DKIM/DMARC verified against **live DNS**
- PSL splitting verified across `com`, `co.uk`, `com.br`, `com.au`, `github.io`, `s3.amazonaws.com`

**Environmental note:** this sandbox blocks TCP DNS and truncates large UDP responses, so `google.com` still resolves to `unknown` here. On a normal network it will resolve properly — that's exactly what the TCP retry is for, and it's the one path I can't fully exercise from here.

## Merge order

`#25` (relicense) → `#24` (monitoring) → this. I'll rebase as each lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_