### PR TITLE
Align feature/machine-learning licensing with the AGPL move

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,79 @@
+# Commercial Licensing
+
+Typo Sniper is dual-licensed.
+
+| | Open source | Commercial |
+|---|---|---|
+| **Licence** | [GNU AGPL v3](LICENSE) | Negotiated, per organisation |
+| **Cost** | Free | Paid |
+| **Source disclosure** | Required (see below) | Not required |
+| **Suitable for** | Internal use, research, open-source projects | Embedding in a proprietary product or hosted service |
+
+## When the AGPL is enough
+
+Most people never need a commercial licence. The AGPL places no restriction on
+**using** Typo Sniper. You can run it, unmodified or modified, to monitor your
+own brands, inside a company of any size, commercially, without publishing
+anything.
+
+The obligation only arises when you **distribute** the software or **offer
+modified versions to others over a network**, and then only for your changes to
+Typo Sniper itself — not for unrelated systems that merely consume its output.
+
+Concretely, all of these are fine under the AGPL alone:
+
+- Running scheduled scans for your employer's domains
+- Modifying detection logic for internal use and keeping those changes private
+- Piping the JSON webhook output into your own closed-source SIEM or ticketing
+  system
+- Publishing research based on its results
+
+## When you need a commercial licence
+
+You need one if you intend to:
+
+- **Offer Typo Sniper, or a modified version, as a hosted or managed service**
+  to third parties without publishing your modifications. AGPL section 13
+  requires that remote users of a modified version can obtain its source.
+- **Embed it in a proprietary product** you distribute to customers, where
+  releasing your product under the AGPL is not acceptable.
+- **Redistribute it under different terms** as part of a commercial offering.
+
+A commercial licence removes the source-disclosure requirement. It does not
+change the software itself: both licences cover identical code.
+
+## Why AGPL rather than a permissive licence
+
+Typo Sniper is brand-protection tooling, and the most likely commercial use of
+it is exactly the case a permissive licence gives away for free: wrapping it in
+a hosted monitoring service. Under Apache-2.0 or MIT, a vendor could take this
+project, build a paid service on it, and contribute nothing back. Under MPL-2.0
+they could do the same as long as they did not modify the original files.
+
+The AGPL closes that gap while leaving ordinary users — the security teams this
+is written for — entirely unaffected. If you are running it to protect your own
+brands, nothing here applies to you.
+
+## Enquiries
+
+Open a [GitHub issue](https://github.com/ChiefGyk3D/typo-sniper/issues) with the
+`licensing` label, or contact the maintainer through the links at
+[links.chiefgyk3d.com](https://links.chiefgyk3d.com/socials).
+
+Please include:
+
+- Your organisation and intended use
+- Whether you plan to distribute, host, or embed the software
+- Expected scale (domains monitored, scan frequency)
+
+## Contributing
+
+Contributions are accepted under the AGPL. Because the project is dual-licensed,
+contributors are asked to agree that their contributions may also be offered
+under the commercial licence — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+*This page summarises the licensing model in plain terms. The [LICENSE](LICENSE)
+file is the binding open-source grant; commercial terms are set out in the
+individual agreement. Nothing here is legal advice.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Typo Sniper
+
+Contributions are welcome — bug reports, detection improvements, new exporters
+and notifiers, documentation, and test coverage all help.
+
+## Licensing of contributions
+
+Typo Sniper is [dual-licensed](COMMERCIAL.md): GNU AGPL v3 for everyone, plus a
+commercial licence for organisations that cannot meet the AGPL's
+source-disclosure terms.
+
+For that model to work, the maintainer has to be able to offer *the whole
+codebase* under both licences. If a contribution were AGPL-only, it could never
+be included in a commercial licence, and the project would have to either
+reimplement it or carry two diverging codebases.
+
+**By opening a pull request you agree that:**
+
+1. You wrote the contribution, or otherwise have the right to submit it under
+   these terms.
+2. You license it under the AGPL v3, and
+3. You grant the maintainer permission to also distribute it under the
+   project's commercial licence.
+
+You keep the copyright to your work. This is permission to relicense, not a
+transfer of ownership.
+
+Sign off your commits to record this:
+
+```bash
+git commit -s -m "Your message"
+```
+
+which appends a `Signed-off-by:` line asserting the
+[Developer Certificate of Origin](https://developercertificate.org/).
+
+If your employer owns your work output, get their sign-off before contributing.
+
+## Development setup
+
+```bash
+git clone https://github.com/ChiefGyk3D/typo-sniper.git
+cd typo-sniper
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+## Before you open a pull request
+
+```bash
+pytest                      # full suite, no network access required
+ruff check src/ tests/      # lint
+```
+
+Both run in CI across Python 3.10–3.13, alongside a CLI smoke test, a Docker
+build, `pip-audit`, and CodeQL.
+
+## What good contributions look like
+
+**Tests are not optional.** This is security tooling: a false negative means a
+phishing domain goes unreported, and a false positive wastes an analyst's
+afternoon. Every behavioural change needs a test that would fail without it.
+
+**Treat scanned data as hostile.** Domain names, WHOIS registrant fields, and
+page titles are written by the people being investigated. Anything that reaches
+a report, an alert, a log, or a model prompt must be escaped or neutralised for
+its destination. There is prior art in `exporters.py` and `notifiers.py`; the
+tests there assert it in both directions.
+
+**Prefer transports that work everywhere.** Registration lookups moved from
+WHOIS to RDAP because TCP/43 is blocked on many corporate networks and fails as
+a silent timeout. New integrations should degrade visibly, not quietly.
+
+**Explain *why* in comments, not *what*.** The code says what it does. Comments
+should capture the reasoning that is not recoverable from reading it.
+
+## Reporting security issues
+
+Please do **not** open a public issue for a vulnerability in Typo Sniper itself.
+Use [GitHub's private advisory
+reporting](https://github.com/ChiefGyk3D/typo-sniper/security/advisories/new),
+or contact the maintainer via
+[links.chiefgyk3d.com](https://links.chiefgyk3d.com/socials).
+
+Findings *produced by* the tool about third-party domains are ordinary output,
+not vulnerabilities in the project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,267 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Typo Sniper is available under a dual-license model:
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-- **Open Source License:** Mozilla Public License 2.0 (MPL 2.0)
-- **Commercial License:** Available for organizations that cannot comply with MPL 2.0 terms.
-    For commercial licensing inquiries, please contact: licensing@yourdomain.com
+                            Preamble
 
----
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-Mozilla Public License Version 2.0
-==================================
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-Copyright (c) 2025 chiefgyk3d
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-1. Definitions
----------------
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
+                       TERMS AND CONDITIONS
 
-1.5. "Incompatible With Secondary Licenses"
-    means
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
+  0. Definitions.
 
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
-    a separate file or files, that is not Covered Software.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-1.8. "License"
-    means this document.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-1.10. "Modifications"
-    means any of the following:
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
+  1. Source Code.
 
-2. License Grants and Conditions
---------------------------------
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-2.1. Grants
-    The initial Contributor hereby grants You a world-wide, royalty-free,
-    non-exclusive license:
-    (a) under intellectual property rights (other than patent or trademark)
-        Licensable by the Contributor, to use, reproduce, modify, display,
-        perform, sublicense and distribute the Contributor Version and
-        Modifications thereof in any form, including without limitation,
-        Source Code Form and Executable Form; and
-    (b) under Patent Claims of the Contributor, to make, use, sell, offer
-        for sale, have made, import, or transfer the Contributor Version
-        and Modifications thereof in any form, including without limitation,
-        Source Code Form and Executable Form.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-2.2. Conditions
-    Your rights under Section 2.1 are subject to the following conditions:
-    (a) You must include a copy of and comply with the License.
-    (b) You must include a copy of and comply with this Exhibit A in each
-        file of the Source Code Form that you distribute.
-    (c) When you distribute the Executable Form, you must include a copy of
-        and comply with this Exhibit A in the documentation and/or other
-        materials provided with the Executable Form.
-    (d) You shall not use the names, trademarks, service marks, or product
-        names of the Contributor, except as required by this License or
-        to the extent expressly authorized in writing by the Contributor.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-3. Responsibilities
---------------------
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-3.1. Distribution of Source Code
-    All distribution of Source Code Form must be accompanied by a copy of
-    this License, including this Exhibit A.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-3.2. Distribution of Executable Form
-    All distribution of Executable Form must be accompanied by a copy of
-    this License, including this Exhibit A, in the documentation and/or
-    other materials provided with the Executable Form.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-3.3. Modifications
-    You are responsible for ensuring that your Modifications, when
-    combined with the Covered Software, comply with the requirements of
-    this License.
+  2. Basic Permissions.
 
-4. Patent Protection
----------------------
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-4.1. Contributor's Patent Rights
-    Subject to the terms and conditions of this License, each Contributor
-    hereby grants You a license under its Patent Claims to make, use, sell,
-    offer for sale, have made, import, or transfer the Contributor Version
-    and Modifications thereof in any form, including without limitation,
-    Source Code Form and Executable Form.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-4.2. Exclusions from Patent License
-    The license granted in Section 4.1 does not apply to any of the
-    following:
-    (a) any patent claim(s) that are not Licensable by the Contributor;
-    (b) any patent claim(s) that would be infringed by the making, using,
-        selling, offering for sale, having made, import, or transfer of
-        Modifications of the Contributor Version that are not included in
-        the Contributor Version as made available by the Contributor; or
-    (c) any patent claim(s) that would be infringed by the combination of
-        the Contributor Version with other software or hardware, or by any
-        other use of the Contributor Version not permitted by this License.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-5. Trademarks
----------------
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-5.1. Contributor's Trademarks
-    This License does not grant you any rights in connection with any of
-    the Contributor's trademarks or service marks.
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-6. Disclaimer
----------------
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-6.1. Warranty Disclaimer
-    Covered Software is provided under this License on an "as is" basis,
-    without warranty of any kind, either express or implied, including,
-    but not limited to, warranties of title, non-infringement, merchantability,
-    or fitness for a particular purpose. The entire risk as to the quality
-    and performance of the Covered Software is with you. Should it prove
-    defective, you assume the cost of all necessary servicing, repair, or
-    correction.
+  4. Conveying Verbatim Copies.
 
-6.2. Exclusion of Consequential Damages
-    In no event shall the Contributor be liable for any indirect, special,
-    incidental, or consequential damages arising out of the use or inability
-    to use the Covered Software, even if the Contributor has been advised
-    of the possibility of such damages.
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
 
-7. Termination
-----------------
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-7.1. Termination by You
-    If you are not in breach of this License, you may terminate this License
-    for any reason.
+  5. Conveying Modified Source Versions.
 
-7.2. Termination by Contributor
-    This License and the rights granted hereunder will terminate
-    automatically if you fail to comply with the terms of this License.
-    The Contributor may also terminate this License at any time by
-    written notice to you.
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
 
-7.3. Effect of Termination
-    Upon termination of this License, you shall cease all use of the
-    Covered Software and destroy all copies of the Covered Software
-    in your possession or control.
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-8. Miscellaneous
-----------------
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-8.1. Governing Law
-    This License shall be governed by and construed in accordance with
-    the laws of the State of Washington, without regard to its conflict
-    of law principles.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
-8.2. Entire Agreement
-    This License constitutes the entire agreement between the parties
-    with respect to the subject matter hereof and supersedes all prior
-    agreements and understandings, whether written or oral, relating to
-    such subject matter.
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-8.3. Modification
-    This License may not be modified except in writing signed by both
-    parties.
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
 
-8.4. Waiver
-    The failure of either party to enforce any rights granted hereunder
-    or to take action against the other party in the event of any breach
-    hereunder shall not be deemed a waiver by that party of its rights
-    hereunder.
+  6. Conveying Non-Source Forms.
 
-8.5. Severability
-    If any provision of this License is held to be invalid or unenforceable,
-    the remaining provisions shall continue in full force and effect.
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
 
-8.6. Assignment
-    You may not assign your rights or obligations under this License
-    without the prior written consent of the Contributor.
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
-8.7. No Third-Party Beneficiaries
-    This License is intended for the sole benefit of the parties hereto
-    and their respective successors and assigns, and nothing herein
-    shall be construed as granting any rights or benefits to any third
-    party.
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-Exhibit A - Source Code Exception
-----------------------------------
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-The provisions of this Exhibit A apply to any Contributor Version that
-is comprised of Source Code Form.
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
 
-1. You may distribute the Contributor Version in Source Code Form only
-   if you include in each file of the Source Code Form that you distribute
-   a copy of and comply with this Exhibit A.
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
 
-2. You may not distribute the Contributor Version in Source Code Form
-   without including a copy of and complying with this Exhibit A.
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
 
-3. If you distribute the Contributor Version in Source Code Form, you
-   must inform recipients that the Source Code Form is available and
-   how they can obtain it.
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
 
-4. You may not impose any further restrictions on the rights granted
-   by this License to the Contributor Version in Source Code Form.
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
 
-5. The Contributor Version in Source Code Form is not subject to
-   patent license grants or exclusions from patent license grants
-   set forth in Sections 4.1 and 4.2 of the License.
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+
+    Copyright (C) 2026  ChiefGyk3D
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,10 @@
 **Advanced Domain Typosquatting Detection Tool**
 
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
-[![License: MPL 2.0 & Commercial](https://img.shields.io/badge/License-MPL%202.0%20%7C%20Commercial-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Commercial licence available](https://img.shields.io/badge/Commercial-available-green.svg)](COMMERCIAL.md)
 [![Version](https://img.shields.io/badge/version-1.1-green.svg)](https://github.com/chiefgyk3d/typo-sniper)
 
-
----
-
-## License
-
-Typo Sniper is available under a dual-license model:
-
-- **Open Source License:** Mozilla Public License 2.0 (MPL 2.0)
-- **Commercial License:** Available for organizations that cannot comply with MPL 2.0 terms.
-  For commercial licensing inquiries, please contact: licensing@yourdomain.com
 
 Detect and monitor typosquatting domains targeting your brand with powerful automation, threat intelligence, and beautiful reporting.
 
@@ -619,7 +610,7 @@ typo-sniper/
 ├── tests/                         # Unit tests
 │   └── __init__.py                # Test package initialization
 ├── docs/                          # Documentation & configs
-│   ├── LICENSE                    # MPL 2.0 License
+│   ├── LICENSE                    # GNU AGPL v3
 │   └── config.yaml.example        # Example configuration
 ├── QUICKSTART.md                  # 🆕 Quick start guide (start here!)
 ├── TESTING.md                     # 🆕 Testing & API setup guide
@@ -1205,7 +1196,7 @@ typo-sniper/
 ├── tests/                  # Unit tests
 │   └── __init__.py         # Test package initialization
 ├── docs/                   # Documentation
-│   ├── LICENSE             # MPL 2.0 License
+│   ├── LICENSE             # GNU AGPL v3
 │   └── config.yaml.example # Example configuration
 ├── requirements.txt        # Python dependencies
 ├── .gitignore              # Git ignore rules
@@ -1398,9 +1389,20 @@ This project is committed to remaining open source under the Mozilla Public Lice
 
 ## License
 
-This project is licensed under the Mozilla Public License 2.0 - see the LICENSE file for details.
+This project is dual-licensed:
 
-**Why MPL 2.0?** This license offers the best of both worlds - it keeps modifications to the core files open source (weak copyleft at file level), while allowing integration with proprietary code. It includes patent protection and is ideal for security tools that may be integrated into larger systems or enterprise environments.
+- **[GNU AGPL v3](LICENSE)** for everyone — free to use, modify, and run.
+- **[Commercial licence](COMMERCIAL.md)** for organisations embedding Typo Sniper
+  in a proprietary product or offering it as a hosted service without publishing
+  their modifications.
+
+**Why AGPL v3?** Using Typo Sniper is unrestricted: run it, modify it, and keep
+those changes private, in any organisation, commercially, for as long as you like.
+The obligation applies only if you *distribute* it or offer a *modified version to
+others over a network* — the one case a permissive licence would give away, since
+the most likely commercial use of brand-protection tooling is wrapping it in a
+hosted service. Security teams monitoring their own brands are unaffected. If the
+AGPL does not fit your situation, a [commercial licence](COMMERCIAL.md) is available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1383,7 +1383,7 @@ Contributions are welcome! Please feel free to:
 - Submit pull requests
 - Improve documentation
 
-This project is committed to remaining open source under the Mozilla Public License 2.0 to ensure the core code stays free while allowing flexible integration.
+This project is committed to remaining open source under the GNU AGPL v3, so the core stays free and improvements to it stay public.
 
 ---
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Typo Sniper - Dockerfile
-# Mozilla Public License 2.0
+# Licensed under the GNU AGPL v3. Commercial licensing: see COMMERCIAL.md
 
 FROM python:3.14-slim
 

--- a/docker/Dockerfile.doppler
+++ b/docker/Dockerfile.doppler
@@ -1,5 +1,5 @@
 # Typo Sniper - Dockerfile with Doppler Support
-# Mozilla Public License 2.0
+# Licensed under the GNU AGPL v3. Commercial licensing: see COMMERCIAL.md
 #
 # This Dockerfile includes optional Doppler CLI for secrets management.
 # Use standard Dockerfile if Doppler is not needed.

--- a/docker/docker-compose.threat-intel.yml
+++ b/docker/docker-compose.threat-intel.yml
@@ -1,5 +1,5 @@
 # Docker Compose for Typo Sniper with Threat Intelligence
-# Mozilla Public License 2.0
+# Licensed under the GNU AGPL v3. Commercial licensing: see COMMERCIAL.md
 #
 # This compose file demonstrates how to run Typo Sniper with API keys
 # loaded from environment variables or .env file.

--- a/docs/LICENSE
+++ b/docs/LICENSE
@@ -1,258 +1,662 @@
-Mozilla Public License Version 2.0
-==================================
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2025 chiefgyk3d
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at https://mozilla.org/MPL/2.0/.
+                            Preamble
 
-1. Definitions
----------------
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-1.5. "Incompatible With Secondary Licenses"
-    means
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
-    a separate file or files, that is not Covered Software.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-1.8. "License"
-    means this document.
+                       TERMS AND CONDITIONS
 
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
+  0. Definitions.
 
-1.10. "Modifications"
-    means any of the following:
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-2. License Grants and Conditions
---------------------------------
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-2.1. Grants
-    The initial Contributor hereby grants You a world-wide, royalty-free,
-    non-exclusive license:
-    (a) under intellectual property rights (other than patent or trademark)
-        Licensable by the Contributor, to use, reproduce, modify, display,
-        perform, sublicense and distribute the Contributor Version and
-        Modifications thereof in any form, including without limitation,
-        Source Code Form and Executable Form; and
-    (b) under Patent Claims of the Contributor, to make, use, sell, offer
-        for sale, have made, import, or transfer the Contributor Version
-        and Modifications thereof in any form, including without limitation,
-        Source Code Form and Executable Form.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-2.2. Conditions
-    Your rights under Section 2.1 are subject to the following conditions:
-    (a) You must include a copy of and comply with the License.
-    (b) You must include a copy of and comply with this Exhibit A in each
-        file of the Source Code Form that you distribute.
-    (c) When you distribute the Executable Form, you must include a copy of
-        and comply with this Exhibit A in the documentation and/or other
-        materials provided with the Executable Form.
-    (d) You shall not use the names, trademarks, service marks, or product
-        names of the Contributor, except as required by this License or
-        to the extent expressly authorized in writing by the Contributor.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-3. Responsibilities
---------------------
+  1. Source Code.
 
-3.1. Distribution of Source Code
-    All distribution of Source Code Form must be accompanied by a copy of
-    this License, including this Exhibit A.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-3.2. Distribution of Executable Form
-    All distribution of Executable Form must be accompanied by a copy of
-    this License, including this Exhibit A, in the documentation and/or
-    other materials provided with the Executable Form.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-3.3. Modifications
-    You are responsible for ensuring that your Modifications, when
-    combined with the Covered Software, comply with the requirements of
-    this License.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-4. Patent Protection
----------------------
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-4.1. Contributor's Patent Rights
-    Subject to the terms and conditions of this License, each Contributor
-    hereby grants You a license under its Patent Claims to make, use, sell,
-    offer for sale, have made, import, or transfer the Contributor Version
-    and Modifications thereof in any form, including without limitation,
-    Source Code Form and Executable Form.
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-4.2. Exclusions from Patent License
-    The license granted in Section 4.1 does not apply to any of the
-    following:
-    (a) any patent claim(s) that are not Licensable by the Contributor;
-    (b) any patent claim(s) that would be infringed by the making, using,
-        selling, offering for sale, having made, import, or transfer of
-        Modifications of the Contributor Version that are not included in
-        the Contributor Version as made available by the Contributor; or
-    (c) any patent claim(s) that would be infringed by the combination of
-        the Contributor Version with other software or hardware, or by any
-        other use of the Contributor Version not permitted by this License.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-5. Trademarks
----------------
+  2. Basic Permissions.
 
-5.1. Contributor's Trademarks
-    This License does not grant you any rights in connection with any of
-    the Contributor's trademarks or service marks.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-6. Disclaimer
----------------
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-6.1. Warranty Disclaimer
-    Covered Software is provided under this License on an "as is" basis,
-    without warranty of any kind, either express or implied, including,
-    but not limited to, warranties of title, non-infringement, merchantability,
-    or fitness for a particular purpose. The entire risk as to the quality
-    and performance of the Covered Software is with you. Should it prove
-    defective, you assume the cost of all necessary servicing, repair, or
-    correction.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-6.2. Exclusion of Consequential Damages
-    In no event shall the Contributor be liable for any indirect, special,
-    incidental, or consequential damages arising out of the use or inability
-    to use the Covered Software, even if the Contributor has been advised
-    of the possibility of such damages.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-7. Termination
-----------------
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-7.1. Termination by You
-    If you are not in breach of this License, you may terminate this License
-    for any reason.
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-7.2. Termination by Contributor
-    This License and the rights granted hereunder will terminate
-    automatically if you fail to comply with the terms of this License.
-    The Contributor may also terminate this License at any time by
-    written notice to you.
+  4. Conveying Verbatim Copies.
 
-7.3. Effect of Termination
-    Upon termination of this License, you shall cease all use of the
-    Covered Software and destroy all copies of the Covered Software
-    in your possession or control.
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
 
-8. Miscellaneous
-----------------
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-8.1. Governing Law
-    This License shall be governed by and construed in accordance with
-    the laws of the State of Washington, without regard to its conflict
-    of law principles.
+  5. Conveying Modified Source Versions.
 
-8.2. Entire Agreement
-    This License constitutes the entire agreement between the parties
-    with respect to the subject matter hereof and supersedes all prior
-    agreements and understandings, whether written or oral, relating to
-    such subject matter.
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
 
-8.3. Modification
-    This License may not be modified except in writing signed by both
-    parties.
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-8.4. Waiver
-    The failure of either party to enforce any rights granted hereunder
-    or to take action against the other party in the event of any breach
-    hereunder shall not be deemed a waiver by that party of its rights
-    hereunder.
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-8.5. Severability
-    If any provision of this License is held to be invalid or unenforceable,
-    the remaining provisions shall continue in full force and effect.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
-8.6. Assignment
-    You may not assign your rights or obligations under this License
-    without the prior written consent of the Contributor.
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-8.7. No Third-Party Beneficiaries
-    This License is intended for the sole benefit of the parties hereto
-    and their respective successors and assigns, and nothing herein
-    shall be construed as granting any rights or benefits to any third
-    party.
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
 
-Exhibit A - Source Code Exception
-----------------------------------
+  6. Conveying Non-Source Forms.
 
-The provisions of this Exhibit A apply to any Contributor Version that
-is comprised of Source Code Form.
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
 
-1. You may distribute the Contributor Version in Source Code Form only
-   if you include in each file of the Source Code Form that you distribute
-   a copy of and comply with this Exhibit A.
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
-2. You may not distribute the Contributor Version in Source Code Form
-   without including a copy of and complying with this Exhibit A.
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-3. If you distribute the Contributor Version in Source Code Form, you
-   must inform recipients that the Source Code Form is available and
-   how they can obtain it.
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-4. You may not impose any further restrictions on the rights granted
-   by this License to the Contributor Version in Source Code Form.
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
 
-5. The Contributor Version in Source Code Form is not subject to
-   patent license grants or exclusions from patent license grants
-   set forth in Sections 4.1 and 4.2 of the License.
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+
+    Copyright (C) 2026  ChiefGyk3D
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,7 +6,7 @@ A powerful tool for detecting and monitoring potential typosquatting domains.
 
 __version__ = "1.1"
 __author__ = "chiefgyk3d"
-__license__ = "MPL-2.0"
+__license__ = "AGPL-3.0-or-later"
 
 from .config import Config
 from .cache import Cache


### PR DESCRIPTION
Cleans up the unfinished dual-license commit (`6d03d3e`) on this branch, which predates the relicensing decision in #25. **No ML code is touched.**

## What was wrong

**1. A placeholder contact address was published.** `licensing@yourdomain.com` — a template value — is live on a public branch, in both `LICENSE` and the README. Anyone wanting to buy a commercial license has nowhere to write.

**2. `LICENSE` had commentary prepended to the license text.**

```
Typo Sniper is available under a dual-license model:
- Open Source License: Mozilla Public License 2.0
- Commercial License: ...
---
Mozilla Public License Version 2.0
```

A LICENSE file should be the verbatim grant and nothing else. Mixing explanation into it muddies which words are actually binding — the summary isn't part of the MPL, but a reader can't tell that from the file. The explanation now lives in `COMMERCIAL.md`, which is what that file is for.

**3. It was MPL-based**, which #25 supersedes.

## Also fixed

The README's license block sat **between the badges and the tagline**, splitting the header:

```
[badges]
---
## License
...dual-license text...
Detect and monitor typosquatting domains targeting your brand...   ← the tagline
```

Removed from the header; the full license section stays at the bottom where it belongs. Badges now show AGPL + commercial.

## Approach

`LICENSE`, `docs/LICENSE`, `COMMERCIAL.md` and `CONTRIBUTING.md` are taken **verbatim from the relicensing branch** rather than rewritten here, so this branch can't drift from the canonical terms. Remaining MPL references in the three Docker headers and the README were caught in a follow-up commit.

## Note on this branch generally

It's currently **3 ahead / 6 behind `main`** and will need rebasing regardless. This PR only stops a placeholder contact address and a malformed LICENSE from sitting on a public branch in the meantime — worth doing now rather than waiting for the rebase.

When we get to the ML work (planned PR 4), my read is that the existing `docs/ML_*.md` scaffolding here is largely documentation ahead of implementation, and the risk model's inputs only started working correctly in v1.1.0. I'd rather train on history accumulated by the new diff engine (#24) than on the old signals. Happy to be told otherwise if you had a different plan for this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_