### PR TITLE
Add learned triage ranking from operator decisions (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,77 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-08-27
+
+Learned triage: the tool starts using your own past decisions to order what it
+shows you.
+
+### Added
+
+- **Learned triage ranking (`--ml-rank`).** The risk score orders findings by a
+  formula that is identical for everyone, but teams differ in what they act on:
+  a bank cares most about mail capability, a consumer SaaS about a cloned login
+  page. This learns that difference from the operator's own judgements and
+  reorders accordingly.
+
+  **The model ranks; it never scores.** Risk scores are unchanged whether this
+  is on or off and remain the number cited in takedown requests — the same rule
+  the AI layer follows, for the same reason. A registrar can check "registered
+  nine days ago, valid SPF and DKIM, serving a login page." It cannot check
+  "our model put it first."
+
+- **Operator labelling (`--label DOMAIN=acted|dismissed`).** Records the
+  decisions that become training data. `dismissed` is treated as first-class
+  and training refuses without it: a model trained only on confirmed-bad
+  examples learns that everything is bad.
+
+- **`--ml-train` and `--ml-status`.** Training reports a cross-validated ROC
+  AUC rather than a training score, since on a forty-label set the difference
+  between those two numbers is the whole story. It refuses below 30 labels and
+  8 of each class, because below that a model fits noise, and a confidently
+  wrong ranking is worse than no ranking — it looks like signal.
+
+- **34 deterministic features**, all traceable to a field a human can look at:
+  lexical, relational (edit distance to the brand, scaled by brand length), DNS,
+  registration age, mail posture, TLS validity, page content, and the
+  deterministic risk score itself. The risk score is included as a feature
+  rather than replaced: it encodes expert judgement that forty labels cannot
+  rediscover, so the model starts from it and learns adjustments.
+
+### Security
+
+- **Model files are JSON and are never unpickled.** `pickle.load` on a model
+  file is arbitrary code execution, and model files get emailed between
+  colleagues and committed to repositories. The trained model is stored as
+  feature names, weights, intercept, and standardisation constants; scoring is
+  a dot product and a sigmoid in pure Python.
+
+  This is why the model is logistic regression rather than a boosted ensemble
+  that would likely score a point or two higher: an opaque model would trade
+  away both the explanation and the safety property, to reorder a list a human
+  reads either way.
+
+- **Training needs scikit-learn; scoring does not.** Hosts that run scans
+  install nothing. Only whoever trains needs `.[ml]`.
+
+### Fixed
+
+- **Training features come from the earliest snapshot of a domain, not the
+  newest.** A domain that was successfully taken down resolves nowhere today.
+  Matching labels to current state would have taught the model that dead
+  domains are the dangerous ones — an inversion of the truth, learned from
+  perfectly good labels, that would rank every parked domain above every live
+  one.
+
+- **The risk-score feature is clamped, not just scaled.** An out-of-range value
+  from a stale record would otherwise dominate every weight in a linear model.
+  Caught by a bounds test over the whole feature vector.
+
+- **A stale model is refused rather than used.** If features are added or
+  reordered after training, the stored model no longer matches the vector it
+  would be scoring; it is rejected with a message to retrain instead of
+  silently producing plausible nonsense.
+
 ## [1.4.0] - 2026-08-27
 
 AI-assisted triage, and secrets management that is actually wired in.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#-contributing)
 - [AI-Assisted Triage](#-ai-assisted-triage) 🤖
+- [Learned Triage Ranking](#-learned-triage-ranking) 🧠
 - [Secrets Management](#-secrets-management) 🔐
 - [Testing & Verification](#-testing-and-verification)
 
@@ -59,6 +60,7 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 | **[Debug Mode Guide](docs/guides/DEBUG_MODE.md)** | 🐛 Debug mode and troubleshooting guide | Troubleshooting, understanding what's running |
 | **[Secrets Management](docs/guides/SECRETS_MANAGEMENT.md)** | 🔐 Complete secrets management guide | Choosing secrets solution, security |
 | **[AI Analysis](docs/guides/AI_ANALYSIS.md)** | 🤖 AI-assisted triage and its injection defences | Enabling `--ai`, choosing a provider |
+| **[ML Triage](docs/guides/ML_TRIAGE.md)** | 🧠 Learned ranking from your own decisions | Labelling findings, training a model |
 | **[Docker Guide](docker/DOCKER.md)** | 🐳 Docker deployment guide | Container deployment |
 | **[Project Structure](PROJECT_STRUCTURE.md)** | 📁 Project organization details | Contributing, understanding codebase |
 
@@ -938,6 +940,52 @@ worried about. For teams that cannot send that to a third party, a local model
 is the difference between using this feature and disabling it.
 
 See **[AI Analysis](docs/guides/AI_ANALYSIS.md)** for the full guide.
+
+**[⬆ Back to Top](#-table-of-contents)**
+
+---
+
+## 🧠 Learned Triage Ranking
+
+Optional, off by default, additive. The risk score orders findings by a formula
+that is the same for everyone — but teams differ in what they act on. A bank
+cares most about mail capability; a consumer SaaS cares most about a cloned
+login page. This learns that difference from your own decisions.
+
+```bash
+# Label as you triage — "dismissed" matters as much as "acted"
+python src/typo_sniper.py --label secure-example-login.com=acted
+python src/typo_sniper.py --label example-fanclub.com=dismissed
+
+python src/typo_sniper.py -i domains.txt --ml-status   # where am I?
+python src/typo_sniper.py -i domains.txt --ml-train    # needs .[ml]
+python src/typo_sniper.py -i domains.txt --ml-rank     # order by the model
+```
+
+**The model ranks. It does not score.** Risk scores are unchanged with this on,
+and remain the number cited in takedown requests — the same rule the AI layer
+follows, for the same reason: a registrar can check "registered nine days ago,
+valid SPF and DKIM, serving a login page." It cannot check "our model put it
+first."
+
+**Training needs scikit-learn. Scoring does not.** A trained model is JSON —
+feature names, weights, intercept, standardisation constants — and the scorer
+is a dot product in pure Python. So scanning hosts install nothing, the model
+is readable enough to audit ("`mail_posture` carries +1.2"), and **nothing is
+ever unpickled**. `pickle.load` on a model file is arbitrary code execution,
+and model files get emailed around. That is why this is logistic regression
+rather than a boosted ensemble that might score a point or two higher.
+
+**Training refuses below 30 labels and 8 of each class.** Below that a model
+fits noise, and a confidently wrong ranking is worse than none because it looks
+like signal.
+
+**Features come from the earliest snapshot of a domain, not the newest.** A
+domain you had taken down resolves nowhere today; training on its current state
+would teach the model that dead domains are the dangerous ones — an inversion
+learned from perfectly good labels.
+
+See **[ML Triage](docs/guides/ML_TRIAGE.md)** for the full guide.
 
 **[⬆ Back to Top](#-table-of-contents)**
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -187,3 +187,26 @@ gcp_project_id: ''
 # service account in CI. Values are read as op://<vault>/<item>/<field>.
 onepassword_vault: ''
 onepassword_item: ''
+
+# ---------------------------------------------------------------------------
+# Learned triage ranking (optional)
+# ---------------------------------------------------------------------------
+# Reorders findings using your own past decisions about what was worth acting
+# on. It ranks; it does not score. The deterministic risk score is unchanged
+# and stays the number reported and cited in takedown requests, because that
+# number has to be reproducible from evidence and a model fitted to one team's
+# judgements is not.
+#
+# Label findings as you triage them:
+#   python src/typo_sniper.py --label evil-example.com=acted
+#   python src/typo_sniper.py --label parked-example.com=dismissed
+#
+# Then, once there are enough of both:
+#   python src/typo_sniper.py -i domains.txt --ml-train    # needs .[ml]
+#   python src/typo_sniper.py -i domains.txt --ml-rank
+#
+# Check progress any time with --ml-status. Training needs scikit-learn;
+# scoring does not — a trained model is JSON and the scorer is pure Python.
+enable_ml_ranking: false
+ml_min_labels: 30                  # Refuse to train below this many labels
+ml_explain_top: 3                  # Feature contributions recorded per finding

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Comprehensive documentation for Typo Sniper.
 - **[API_KEYS_SETUP.md](guides/API_KEYS_SETUP.md)** - Setting up URLScan.io API keys
 - **[SECRETS_MANAGEMENT.md](guides/SECRETS_MANAGEMENT.md)** - Doppler, AWS, Vault, Azure, GCP, 1Password
 - **[AI_ANALYSIS.md](guides/AI_ANALYSIS.md)** - AI-assisted triage with Claude, OpenAI, Gemini, or Ollama
+- **[ML_TRIAGE.md](guides/ML_TRIAGE.md)** - Learned ranking from your own triage decisions
 - **[DEBUG_MODE.md](guides/DEBUG_MODE.md)** - Debug mode usage
 - **[DEBUG_IMPLEMENTATION.md](guides/DEBUG_IMPLEMENTATION.md)** - Debug system architecture
 - **[PERFORMANCE_OPTIMIZATION.md](guides/PERFORMANCE_OPTIMIZATION.md)** - Performance tuning
@@ -33,7 +34,8 @@ docs/
     ├── PERFORMANCE_OPTIMIZATION.md     # Performance tuning
     ├── QUICKSTART.md                   # Quick start guide
     ├── SECRETS_MANAGEMENT.md           # Secrets management
-    └── AI_ANALYSIS.md                  # AI-assisted triage
+    ├── AI_ANALYSIS.md                  # AI-assisted triage
+    └── ML_TRIAGE.md                    # Learned triage ranking
 ```
 
 ## Documentation by Topic

--- a/docs/config.yaml.example
+++ b/docs/config.yaml.example
@@ -187,3 +187,26 @@ gcp_project_id: ''
 # service account in CI. Values are read as op://<vault>/<item>/<field>.
 onepassword_vault: ''
 onepassword_item: ''
+
+# ---------------------------------------------------------------------------
+# Learned triage ranking (optional)
+# ---------------------------------------------------------------------------
+# Reorders findings using your own past decisions about what was worth acting
+# on. It ranks; it does not score. The deterministic risk score is unchanged
+# and stays the number reported and cited in takedown requests, because that
+# number has to be reproducible from evidence and a model fitted to one team's
+# judgements is not.
+#
+# Label findings as you triage them:
+#   python src/typo_sniper.py --label evil-example.com=acted
+#   python src/typo_sniper.py --label parked-example.com=dismissed
+#
+# Then, once there are enough of both:
+#   python src/typo_sniper.py -i domains.txt --ml-train    # needs .[ml]
+#   python src/typo_sniper.py -i domains.txt --ml-rank
+#
+# Check progress any time with --ml-status. Training needs scikit-learn;
+# scoring does not — a trained model is JSON and the scorer is pure Python.
+enable_ml_ranking: false
+ml_min_labels: 30                  # Refuse to train below this many labels
+ml_explain_top: 3                  # Feature contributions recorded per finding

--- a/docs/guides/ML_TRIAGE.md
+++ b/docs/guides/ML_TRIAGE.md
@@ -1,0 +1,188 @@
+# Learned Triage Ranking
+
+A scan of a well-known brand returns hundreds of registered permutations, and
+the risk score orders them by a formula that is the same for everyone. But
+teams differ in what they act on. A bank cares most about mail capability,
+because that is the prerequisite for the wire-fraud email. A consumer SaaS
+cares most about a cloned login page. A game studio may ignore both and care
+about anything selling fake keys.
+
+This feature learns that difference from your own past decisions and reorders
+findings accordingly. It is optional, off by default, and strictly additive.
+
+## The rule this feature is built around
+
+**The model ranks. It does not score.**
+
+The deterministic risk score is unchanged whether this is on or off, and it
+stays the number that appears in reports and takedown requests. That is the
+same rule the AI triage layer follows, for the same reason: a takedown request
+to a registrar has to rest on evidence anyone can reproduce. "Registered nine
+days ago, valid SPF and DKIM, serving a login page, scored 85" is an argument
+a registrar can check. "Our model put it first" is not.
+
+What the model changes is the **order** of a list a human reads, and which
+findings surface at the top of a long report.
+
+## Getting started
+
+There is no pre-trained model, and there deliberately isn't one. A model
+shipped with the tool would encode some other organisation's idea of what
+matters, which is exactly the thing this feature exists to replace.
+
+### 1. Label findings as you triage them
+
+```bash
+# Worth acting on: escalated, reported, blocked, taken down
+python src/typo_sniper.py --label secure-example-login.com=acted
+
+# Reviewed and judged not worth acting on
+python src/typo_sniper.py --label example-fanclub.com=dismissed
+
+# Several at once, with a note
+python src/typo_sniper.py \
+  --label a.com=acted --label b.com=dismissed
+```
+
+**`dismissed` matters as much as `acted`**, and it is the half teams forget.
+A model trained only on confirmed-bad examples learns that everything is bad.
+If you look at a finding and decide it is nothing, that decision is training
+data — record it.
+
+### 2. Check where you are
+
+```bash
+python src/typo_sniper.py -i domains.txt --ml-status
+```
+
+```
+Labels
+  acted:     24
+  dismissed: 19
+  ✓ 43 labels (24 acted, 19 dismissed)
+
+Model
+  trained on 43 labels (24 acted, 19 dismissed)
+  cross-validated ROC AUC: 0.831 (±0.074, 5 folds)
+  most influential features
+    mail_posture               +1.204
+    age_days_log               +0.887
+    title_parked_words         -0.771
+```
+
+### 3. Train
+
+```bash
+pip install -e ".[ml]"
+python src/typo_sniper.py -i domains.txt --ml-train
+```
+
+Training refuses to run below **30 labels total** and **8 of each class**.
+Those floors are not arbitrary politeness: below them a model fits noise, and
+a confidently wrong ranking is worse than no ranking, because it looks like
+signal.
+
+### 4. Rank
+
+```bash
+python src/typo_sniper.py -i domains.txt --ml-rank
+```
+
+Findings are ordered by the model. Each one carries `ml_rank` and `ml_explain`
+in the JSON export, so a reordered report says why it was reordered.
+
+## Why logistic regression
+
+A gradient boosted ensemble would probably score a point or two higher on the
+same labels. Three things made a linear model the better trade here:
+
+- **It explains itself.** You can open the model file and read that
+  `mail_posture` carries weight +1.2 and `title_parked_words` carries -0.8.
+  For a tool whose output justifies takedown requests, "why is this first?"
+  needs an answer.
+- **It is small.** Label sets here are tens of examples, not millions. A
+  high-capacity model on forty labels memorises them.
+- **It needs no runtime dependency.** See below.
+
+## Training needs scikit-learn. Scoring does not.
+
+The trained model is stored as **JSON** — feature names, weights, intercept,
+and the standardisation constants — and scoring is a dot product and a sigmoid
+written in plain Python. So:
+
+- A host that runs scans installs nothing. Only whoever trains needs `.[ml]`.
+- A model file is readable and reviewable, like any other config.
+- **Nothing is ever unpickled.** `pickle.load` on a model file is arbitrary
+  code execution, and model files get emailed between colleagues and committed
+  to repositories. JSON cannot execute.
+
+That last point is a security property, not a convenience, and it is why the
+format is fixed even though pickle would have been less code.
+
+## What the model sees
+
+34 features, all deterministic and all traceable to a field you can look at:
+
+| Group | Examples |
+|---|---|
+| Lexical | length, digits, hyphens, punycode, entropy |
+| Relational | edit distance to the brand, distance relative to brand length, whether the brand name is contained, TLD match |
+| DNS | A and MX presence and count, with failed-lookup sentinels excluded |
+| Registration | age (log-scaled), recency, whether the registrant is privacy-shielded |
+| Posture | mail capability, TLS validity, live HTTP, certificate count |
+| Content | brand mentioned in the title, credential words, parked-page words |
+| Prior | the deterministic risk score |
+
+The risk score is included as a feature rather than replaced. It encodes
+expert judgement that forty labels cannot rediscover, so the model starts from
+it and learns adjustments, instead of relearning the problem from scratch.
+
+Two details worth knowing:
+
+- **A failed lookup is not evidence.** A `mail_posture` of `unknown` scores the
+  same as `none` rather than being treated as a signal, and DNS sentinels like
+  `!ServFail` are not counted as records.
+- **Age is log-scaled.** The difference between 3 and 30 days matters far more
+  than the difference between 1000 and 1027.
+
+## Features come from the *earliest* snapshot
+
+When training, each label is matched against the oldest retained scan that saw
+that domain — not the newest.
+
+This matters more than it sounds. A domain you successfully had taken down
+resolves nowhere today. Training on its current state would teach the model
+that **dead domains are the dangerous ones**: an inversion of the truth,
+learned from perfectly good labels, that would then rank every parked domain
+above every live one. The earliest snapshot is the closest available record to
+the state the domain was in when you judged it.
+
+A consequence: labels for domains that have aged out of the history retention
+window cannot be used, and `--ml-status` reports how many are in that state.
+Raise `history_retain` if you see that number growing.
+
+## Failure behaviour
+
+Every failure mode is additive-only:
+
+- No model trained → findings are ordered by risk score, as they always were.
+- A model trained on an older feature set → refused with a message telling you
+  to retrain, rather than silently scoring a mismatched vector and producing
+  plausible nonsense.
+- A corrupt model file → logged, ignored, scan continues.
+- Scoring throws on one finding → that finding sorts last and keeps every
+  deterministic field it had.
+
+There is no path where ranking failing loses a finding or changes a risk score.
+
+## When it will not help
+
+Be honest with yourself about the label set:
+
+- **If your decisions track the risk score exactly**, the model has nothing to
+  learn and will reproduce the existing order. That is a real outcome and
+  `--ml-status` will show it as an unremarkable ROC AUC near 0.5–0.6.
+- **If you only label the bad ones**, training refuses, by design.
+- **If your criteria change** — new brand, new threat, new policy — the old
+  labels now describe a different problem. Retrain, and consider clearing
+  labels that no longer reflect how you would decide today.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,15 @@ openai = ["openai>=1.50.0"]
 gemini = ["google-genai>=1.0.0"]
 # ollama needs no SDK: it is plain HTTP to a daemon you run
 ai-all = [
+    "scikit-learn>=1.3.0",
     "anthropic>=0.40.0",
     "openai>=1.50.0",
     "google-genai>=1.0.0",
 ]
+
+# Training the learned triage model. Scoring needs nothing: a trained model is
+# JSON, and the scorer is a dot product in pure Python.
+ml = ["scikit-learn>=1.3.0"]
 
 # Secrets backends. Doppler and HashiCorp Vault need nothing installed — both
 # are reached over HTTPS with the standard library — so they are absent here.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,8 @@ pytest==8.4.2
 pytest-asyncio==1.2.0
 pytest-cov==7.0.0
 ruff==0.14.4
+
+# Training the triage ranking model. Only training needs this — scoring is
+# pure Python, so hosts that run scans never install it. Present here so CI
+# exercises the training path rather than skipping it.
+scikit-learn==1.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,7 @@ ruff==0.14.4
 # Training the triage ranking model. Only training needs this — scoring is
 # pure Python, so hosts that run scans never install it. Present here so CI
 # exercises the training path rather than skipping it.
-scikit-learn==1.9.0
+#
+# Held at 1.7.x: this project supports Python 3.10, and scikit-learn 1.8
+# dropped it. Raise this pin only alongside requires-python.
+scikit-learn==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,13 @@ python-dotenv==1.2.3
 # Google Cloud Secret Manager
 # google-cloud-secret-manager==2.24.0
 
+# Learned triage ranking (--ml-train)
+#
+# Only training needs this. Scoring a trained model is pure Python: the model
+# is JSON, so hosts that run scans install nothing.
+#
+# scikit-learn==1.9.0
+
 # AI providers for --ai triage
 #
 # Ollama needs no SDK: it is plain HTTP to a daemon you run, and no scan data

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ python-dotenv==1.2.3
 # Only training needs this. Scoring a trained model is pure Python: the model
 # is JSON, so hosts that run scans install nothing.
 #
-# scikit-learn==1.9.0
+# scikit-learn==1.7.2  # 1.8+ requires Python 3.11
 
 # AI providers for --ai triage
 #

--- a/src/config.py
+++ b/src/config.py
@@ -133,6 +133,13 @@ class Config:
     ai_min_risk_score: int = 30        # Skip AI on findings below this score
     ai_explain_changes: bool = True    # Also summarise what changed since last scan
 
+    # Learned triage. Ranks findings using the operator's own past decisions;
+    # it never replaces the deterministic risk score, which stays the number
+    # reported and cited in takedown requests.
+    enable_ml_ranking: bool = False
+    ml_min_labels: int = 30            # Refuse to train below this many labels
+    ml_explain_top: int = 3            # Feature contributions shown per finding
+
     # Combo-squatting keywords specific to your brand. Product names, campaign
     # names and support portals are far better bait than the generic list.
     custom_keywords: list = field(default_factory=list)

--- a/src/ml/__init__.py
+++ b/src/ml/__init__.py
@@ -1,0 +1,33 @@
+"""
+Learned triage for Typo Sniper.
+
+Optional and strictly additive. Detection and the deterministic risk score are
+unchanged with no model trained; this layer only reorders a list that a human
+reads, using the operator's own past decisions about what was worth acting on.
+
+Training needs scikit-learn; scoring does not. Models are stored as inspectable
+JSON and are never unpickled.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+from .dataset import Dataset, build
+from .features import FEATURE_NAMES, extract
+from .labels import ACTED, DISMISSED, LabelStore
+from .model import TriageModel, load, sklearn_available, train
+
+__all__ = [
+    'ACTED',
+    'DISMISSED',
+    'FEATURE_NAMES',
+    'Dataset',
+    'LabelStore',
+    'TriageModel',
+    'build',
+    'extract',
+    'load',
+    'sklearn_available',
+    'train',
+]

--- a/src/ml/dataset.py
+++ b/src/ml/dataset.py
@@ -1,0 +1,97 @@
+"""
+Build a training set from scan history and operator labels.
+
+The join is the interesting part. A label says "example-login.com was worth
+acting on"; the features have to come from what the domain looked like when
+that judgement was made, not from what it looks like now. A domain that has
+since been taken down resolves nowhere today, and training on its current
+state would teach the model that dead domains are the dangerous ones — an
+inversion of the truth, learned from perfectly good labels.
+
+So each label is matched against the **earliest** history snapshot containing
+that domain, which is the closest available record to the state it was in when
+it first warranted attention.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import features
+from .labels import ACTED, LabelStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Dataset:
+    """Feature vectors paired with their labels."""
+
+    vectors: list[list[float]] = field(default_factory=list)
+    targets: list[int] = field(default_factory=list)
+    domains: list[str] = field(default_factory=list)
+    monitored_domains: list[str] = field(default_factory=list)
+    unmatched: list[str] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return len(self.targets)
+
+    @property
+    def class_counts(self) -> dict[str, int]:
+        acted = sum(self.targets)
+        return {'acted': acted, 'dismissed': len(self.targets) - acted}
+
+
+def build(history, labels: LabelStore, monitored_domains: list[str]) -> Dataset:
+    """
+    Join labelled domains to their earliest recorded state.
+
+    Args:
+        history: ScanHistory instance
+        labels: LabelStore holding operator judgements
+        monitored_domains: Brands whose history should be searched
+
+    Returns:
+        A Dataset; domains with a label but no history land in .unmatched
+    """
+    dataset = Dataset()
+
+    # domain -> (snapshot, monitored_domain), taking the oldest scan that saw it
+    earliest: dict[str, tuple[dict[str, Any], str]] = {}
+
+    for monitored in monitored_domains:
+        scans = history.load(monitored)
+        # load() returns newest first, so walking in reverse ends on the oldest
+        for snapshot in reversed(scans):
+            for domain, perm in (snapshot.get('permutations') or {}).items():
+                key = features.normalise_domain(domain)
+                if key and key not in earliest:
+                    record = dict(perm)
+                    record['domain'] = domain
+                    earliest[key] = (record, monitored)
+
+    for domain, entry in labels.all().items():
+        match = earliest.get(domain)
+        if match is None:
+            # Labelled but never seen in a retained scan: either the label
+            # predates the history window or the domain was labelled by hand.
+            dataset.unmatched.append(domain)
+            continue
+
+        record, monitored = match
+        dataset.vectors.append(features.extract(record, monitored))
+        dataset.targets.append(1 if entry['label'] == ACTED else 0)
+        dataset.domains.append(domain)
+        dataset.monitored_domains.append(monitored)
+
+    if dataset.unmatched:
+        logger.info(
+            f'{len(dataset.unmatched)} labelled domain(s) had no scan history '
+            f'and were skipped'
+        )
+
+    return dataset

--- a/src/ml/features.py
+++ b/src/ml/features.py
@@ -1,0 +1,274 @@
+"""
+Feature extraction for learned triage.
+
+Turns one permutation record into a fixed-length numeric vector. Everything
+here is pure and deterministic: the same record always produces the same
+vector, with no network access and no dependencies beyond the standard library.
+That matters for two reasons. A feature vector computed at scan time must match
+one computed later from history, or a model trained on the second scores the
+first incorrectly. And a security tool's inputs should be auditable — every
+number below can be traced to a field a human can look at.
+
+Feature groups:
+
+  * lexical   - what the name itself looks like next to the brand
+  * dns       - whether it resolves, and to how much
+  * registration - how new it is, and whether the registrant is hidden
+  * posture   - mail capability, TLS, live HTTP, certificates
+  * relational - how the name relates to the domain being defended
+
+The deterministic risk score is deliberately included as a feature rather than
+replaced by the model. It encodes expert judgement that a small label set
+cannot rediscover, and letting the model start from it means a handful of
+labels can adjust the ranking instead of having to relearn the problem.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+import math
+import re
+from typing import Any
+
+# Postures ordered by how much deliberate work they represent
+_MAIL_POSTURE_RANK = {
+    'none': 0.0,
+    'unknown': 0.0,     # A failed lookup is not evidence; it scores as absent
+    'receive-only': 0.25,
+    'partial': 0.5,
+    'provisioned': 0.75,
+    'hardened': 1.0,
+}
+
+# Words that appear in the title of a page built to harvest credentials
+_CREDENTIAL_WORDS = (
+    'login', 'log in', 'sign in', 'signin', 'account', 'password',
+    'verify', 'secure', 'update', 'billing', 'invoice', 'wallet',
+    'authenticate', 'confirm', 'suspended',
+)
+
+_PARKED_WORDS = (
+    'for sale', 'domain for sale', 'parked', 'buy this domain',
+    'coming soon', 'under construction', 'godaddy', 'sedo',
+)
+
+# Registrant fields that mean "hidden" rather than naming a person
+_PRIVACY_WORDS = (
+    'privacy', 'redacted', 'whois guard', 'whoisguard', 'protected',
+    'not disclosed', 'data protected', 'gdpr', 'withheld',
+)
+
+# The order here IS the model's input order. Appending is safe; reordering or
+# removing invalidates every previously trained model, which is why the list is
+# explicit rather than derived from a dict at runtime.
+FEATURE_NAMES = (
+    'risk_score',
+    'name_length',
+    'label_length_delta',
+    'digit_count',
+    'hyphen_count',
+    'is_punycode',
+    'shannon_entropy',
+    'edit_distance',
+    'edit_distance_ratio',
+    'shares_registrable_stem',
+    'tld_matches_brand',
+    'fuzzer_is_homoglyph',
+    'fuzzer_is_tld_swap',
+    'fuzzer_is_combosquat',
+    'has_a_record',
+    'a_record_count',
+    'has_mx_record',
+    'mx_record_count',
+    'is_registered',
+    'age_days_log',
+    'is_recent',
+    'registrant_is_private',
+    'has_registrant',
+    'mail_posture',
+    'http_active',
+    'https_active',
+    'tls_verified',
+    'tls_invalid',
+    'has_title',
+    'title_mentions_brand',
+    'title_credential_words',
+    'title_parked_words',
+    'certificates_log',
+    'urlscan_malicious',
+)
+
+FEATURE_COUNT = len(FEATURE_NAMES)
+
+
+def _entropy(text: str) -> float:
+    """Shannon entropy of a string, in bits per character."""
+    if not text:
+        return 0.0
+    counts: dict[str, int] = {}
+    for char in text:
+        counts[char] = counts.get(char, 0) + 1
+    total = len(text)
+    return -sum((n / total) * math.log2(n / total) for n in counts.values())
+
+
+def _edit_distance(a: str, b: str) -> int:
+    """
+    Levenshtein distance between two strings.
+
+    Implemented here rather than pulled from a dependency: it is fifteen lines,
+    and a scoring path that must stay dependency-free cannot import one.
+
+    Args:
+        a: First string
+        b: Second string
+
+    Returns:
+        Minimum single-character edits to turn a into b
+    """
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    previous = list(range(len(b) + 1))
+    for i, char_a in enumerate(a, 1):
+        current = [i]
+        for j, char_b in enumerate(b, 1):
+            current.append(min(
+                previous[j] + 1,          # deletion
+                current[j - 1] + 1,       # insertion
+                previous[j - 1] + (char_a != char_b),  # substitution
+            ))
+        previous = current
+    return previous[-1]
+
+
+def _split(domain: str) -> tuple[str, str]:
+    """Split a domain into its first label and the rest."""
+    parts = (domain or '').lower().split('.')
+    return (parts[0], '.'.join(parts[1:])) if len(parts) > 1 else (parts[0], '')
+
+
+def _contains_any(text: str, words) -> int:
+    lowered = (text or '').lower()
+    return sum(1 for word in words if word in lowered)
+
+
+def extract(perm: dict[str, Any], monitored_domain: str) -> list[float]:
+    """
+    Build the feature vector for one permutation.
+
+    Accepts either a live scan record or a history snapshot; the fields the two
+    share are exactly the ones used here, so a vector built from history is
+    identical to the one built at scan time.
+
+    Args:
+        perm: Permutation record or history snapshot
+        monitored_domain: The brand domain being defended
+
+    Returns:
+        A list of floats, in FEATURE_NAMES order
+    """
+    domain = str(perm.get('domain') or '').lower()
+    name, tld = _split(domain)
+    brand_name, brand_tld = _split(monitored_domain)
+
+    # A live record nests HTTP data; a snapshot flattens it. Read both.
+    threat = perm.get('threat_intel') or {}
+    http = threat.get('http_probe') or {}
+    ct = threat.get('certificate_transparency') or {}
+    urlscan = threat.get('urlscan') or {}
+
+    def field(key, http_key=None, default=None):
+        if key in perm:
+            return perm.get(key)
+        return http.get(http_key or key, default)
+
+    dns_a = [r for r in (perm.get('dns_a') or []) if not str(r).startswith('!')]
+    dns_mx = [r for r in (perm.get('dns_mx') or []) if not str(r).startswith('!')]
+
+    fuzzer = str(perm.get('fuzzer') or '').lower()
+    registrant = str(perm.get('whois_registrant') or perm.get('whois_org') or '')
+    title = str(field('title', 'title') or '')
+
+    age_days = perm.get('created_days_ago')
+    registered = bool(dns_a or perm.get('whois_registrar') or age_days is not None)
+
+    tls_verified = field('tls_verified', 'tls_verified')
+    https_active = bool(field('https_active', 'https_active'))
+
+    distance = _edit_distance(name, brand_name)
+
+    values = {
+        # Clamped, not just scaled. The scorer keeps this in 0-100, but an
+        # out-of-range value from a stale record or a future change would
+        # otherwise dominate every weight in a linear model.
+        'risk_score': min(max(float(perm.get('risk_score') or 0), 0.0), 100.0) / 100.0,
+        'name_length': min(len(name), 63) / 63.0,
+        'label_length_delta': min(abs(len(name) - len(brand_name)), 20) / 20.0,
+        'digit_count': min(sum(c.isdigit() for c in name), 10) / 10.0,
+        'hyphen_count': min(name.count('-'), 5) / 5.0,
+        'is_punycode': float(domain.startswith('xn--') or '.xn--' in domain),
+        'shannon_entropy': min(_entropy(name), 6.0) / 6.0,
+        'edit_distance': min(distance, 10) / 10.0,
+        # Distance relative to brand length: one edit in a 4-letter name is a
+        # far bigger change than one edit in a 20-letter name.
+        'edit_distance_ratio': min(distance / max(len(brand_name), 1), 1.0),
+        'shares_registrable_stem': float(bool(brand_name) and brand_name in name),
+        'tld_matches_brand': float(bool(tld) and tld == brand_tld),
+        'fuzzer_is_homoglyph': float('homoglyph' in fuzzer or 'homograph' in fuzzer),
+        'fuzzer_is_tld_swap': float('tld' in fuzzer),
+        'fuzzer_is_combosquat': float('combo' in fuzzer or 'keyword' in fuzzer),
+        'has_a_record': float(bool(dns_a)),
+        'a_record_count': min(len(dns_a), 5) / 5.0,
+        'has_mx_record': float(bool(dns_mx)),
+        'mx_record_count': min(len(dns_mx), 5) / 5.0,
+        'is_registered': float(registered),
+        # Log-scaled: the difference between 3 and 30 days old matters far more
+        # than the difference between 1000 and 1027.
+        'age_days_log': (
+            0.0 if age_days is None
+            else 1.0 - min(math.log10(max(float(age_days), 1.0) + 1) / 4.0, 1.0)
+        ),
+        'is_recent': float(bool(perm.get('is_recent'))),
+        'registrant_is_private': float(_contains_any(registrant, _PRIVACY_WORDS) > 0),
+        'has_registrant': float(bool(registrant.strip())),
+        'mail_posture': _MAIL_POSTURE_RANK.get(
+            str((perm.get('mail_intel') or {}).get('posture')
+                or perm.get('mail_posture') or 'unknown').lower(), 0.0),
+        'http_active': float(bool(field('http_active', 'http_active'))),
+        'https_active': float(https_active),
+        'tls_verified': float(tls_verified is True),
+        # A domain that answers on 443 with an untrusted certificate is a
+        # distinct state from one that does not answer at all.
+        'tls_invalid': float(https_active and tls_verified is False),
+        'has_title': float(bool(title.strip())),
+        'title_mentions_brand': float(
+            bool(brand_name) and brand_name in title.lower()
+        ),
+        'title_credential_words': min(
+            _contains_any(title, _CREDENTIAL_WORDS), 3) / 3.0,
+        'title_parked_words': min(_contains_any(title, _PARKED_WORDS), 2) / 2.0,
+        'certificates_log': min(
+            math.log10(float(ct.get('certificates_found')
+                             or perm.get('certificates_found') or 0) + 1) / 3.0, 1.0),
+        'urlscan_malicious': float(bool(
+            urlscan.get('malicious') or perm.get('urlscan_malicious')
+        )),
+    }
+
+    return [float(values[fname]) for fname in FEATURE_NAMES]
+
+
+def describe(vector: list[float]) -> dict[str, float]:
+    """Pair a feature vector with its names, for inspection and debugging."""
+    return dict(zip(FEATURE_NAMES, vector, strict=False))
+
+
+def normalise_domain(domain: str) -> str:
+    """Canonical form used as a label key."""
+    return re.sub(r'^\.+|\.+$', '', str(domain or '').strip().lower())

--- a/src/ml/labels.py
+++ b/src/ml/labels.py
@@ -1,0 +1,176 @@
+"""
+Operator feedback, stored as training labels.
+
+A learned model needs to know what a correct answer looks like, and for this
+problem only the operator knows. Two domains can carry identical signals while
+one is a competitor's legitimate product name and the other is bait; no amount
+of DNS data settles that. So the label is a record of a human decision:
+
+  * ``acted``     - worth acting on: escalated, reported, blocked, taken down
+  * ``dismissed`` - looked at and judged not worth acting on
+
+"Dismissed" is as valuable as "acted" and is the half operators forget to
+record. A model trained only on confirmed-bad examples learns that everything
+is bad.
+
+Labels are stored separately from scan history and are never expired by the
+history retention window. A judgement made once should not evaporate because
+thirty scans have run since.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from .features import normalise_domain
+
+ACTED = 'acted'
+DISMISSED = 'dismissed'
+VALID_LABELS = (ACTED, DISMISSED)
+
+# Below this, a model is fitting noise. Reported rather than silently ignored.
+MIN_LABELS_TO_TRAIN = 30
+MIN_PER_CLASS = 8
+
+
+class LabelStore:
+    """Persist and query operator judgements."""
+
+    def __init__(self, state_dir: Path):
+        """
+        Args:
+            state_dir: Directory holding scan state; labels live alongside it
+        """
+        self.path = Path(state_dir) / 'labels.json'
+        self.logger = logging.getLogger(__name__)
+        self._labels: dict[str, dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            with open(self.path, encoding='utf-8') as handle:
+                data = json.load(handle)
+            entries = data.get('labels', {})
+            if isinstance(entries, dict):
+                self._labels = {
+                    k: v for k, v in entries.items()
+                    if isinstance(v, dict) and v.get('label') in VALID_LABELS
+                }
+        except (OSError, json.JSONDecodeError) as e:
+            # A corrupt label file must not stop a scan. It is training data,
+            # not something the scan depends on.
+            self.logger.warning(
+                f'Could not read labels from {self.path} ({type(e).__name__}); '
+                f'continuing with none'
+            )
+
+    def _save(self) -> bool:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.path, 'w', encoding='utf-8') as handle:
+                json.dump({'version': 1, 'labels': self._labels}, handle, indent=2)
+            return True
+        except OSError as e:
+            self.logger.error(f'Could not write labels: {type(e).__name__}')
+            return False
+
+    def set(
+        self,
+        domain: str,
+        label: str,
+        monitored_domain: str | None = None,
+        note: str | None = None,
+    ) -> bool:
+        """
+        Record a judgement about one domain.
+
+        Args:
+            domain: The permutation being judged
+            label: One of 'acted' or 'dismissed'
+            monitored_domain: The brand it was found against
+            note: Optional free-text reason
+
+        Returns:
+            True if the label was stored
+
+        Raises:
+            ValueError: If the label is not recognised
+        """
+        if label not in VALID_LABELS:
+            raise ValueError(
+                f"Unknown label '{label}'; expected one of {', '.join(VALID_LABELS)}"
+            )
+
+        key = normalise_domain(domain)
+        if not key:
+            raise ValueError('A label needs a domain')
+
+        previous = self._labels.get(key, {})
+        self._labels[key] = {
+            'label': label,
+            'monitored_domain': normalise_domain(monitored_domain or
+                                                 previous.get('monitored_domain') or ''),
+            'note': (note or '').strip()[:500] or None,
+            'labelled_at': time.time(),
+            # Kept so a changed judgement is visible rather than silent
+            'previous_label': previous.get('label'),
+        }
+        return self._save()
+
+    def remove(self, domain: str) -> bool:
+        """Delete a label. Returns True if one was present."""
+        key = normalise_domain(domain)
+        if key in self._labels:
+            del self._labels[key]
+            self._save()
+            return True
+        return False
+
+    def get(self, domain: str) -> str | None:
+        """The label for a domain, or None."""
+        entry = self._labels.get(normalise_domain(domain))
+        return entry.get('label') if entry else None
+
+    def all(self) -> dict[str, dict[str, Any]]:
+        """Every stored label, keyed by domain."""
+        return dict(self._labels)
+
+    def counts(self) -> dict[str, int]:
+        """How many of each label are stored."""
+        result = dict.fromkeys(VALID_LABELS, 0)
+        for entry in self._labels.values():
+            result[entry['label']] = result.get(entry['label'], 0) + 1
+        return result
+
+    def readiness(self) -> tuple[bool, str]:
+        """
+        Whether there is enough labelled data to train.
+
+        Returns:
+            Tuple of (ready, an explanation an operator can act on)
+        """
+        counts = self.counts()
+        total = sum(counts.values())
+        acted, dismissed = counts.get(ACTED, 0), counts.get(DISMISSED, 0)
+
+        if total < MIN_LABELS_TO_TRAIN:
+            return False, (
+                f'{total} of {MIN_LABELS_TO_TRAIN} labels needed to train. '
+                f'Label findings with --label <domain>=acted|dismissed.'
+            )
+        if acted < MIN_PER_CLASS or dismissed < MIN_PER_CLASS:
+            short = ACTED if acted < MIN_PER_CLASS else DISMISSED
+            return False, (
+                f'Need at least {MIN_PER_CLASS} of each label to train; '
+                f"have {acted} acted and {dismissed} dismissed. A model cannot "
+                f"learn a boundary from one side of it — more '{short}' needed."
+            )
+        return True, f'{total} labels ({acted} acted, {dismissed} dismissed)'

--- a/src/ml/model.py
+++ b/src/ml/model.py
@@ -1,0 +1,266 @@
+"""
+Learned triage ranking.
+
+A deliberate asymmetry runs through this module: **training needs scikit-learn,
+scoring does not.**
+
+The trained model is persisted as JSON — feature names, weights, intercept, and
+the standardisation constants — and scoring is a dot product and a sigmoid,
+written out in plain Python below. Three things follow from that:
+
+  * A scanner host never installs scikit-learn. Only whoever trains does.
+  * A model file is readable. You can open it and see that ``mail_posture``
+    carries weight 1.8 and ``title_parked_words`` carries -2.1. For a tool whose
+    output justifies takedown requests, "why did it rank this first" has to have
+    an answer, and an inspectable linear model gives one.
+  * **Nothing is ever unpickled.** ``pickle.load`` on a model file is arbitrary
+    code execution, and model files get emailed around and committed to repos.
+    JSON cannot execute.
+
+That last point is why this is logistic regression rather than a gradient
+boosted ensemble that would likely score a point or two higher. An opaque model
+that has to be unpickled would trade away both the explanation and the safety
+property, to rank a list that a human reads either way.
+
+What the model is for
+---------------------
+It **ranks**. It does not score. The deterministic risk score stays the number
+that appears in reports and takedown requests, for the same reason the LLM is
+not allowed to produce one: that number has to be reproducible and explainable
+from evidence, and a model fitted to one operator's judgements is neither. What
+the model adds is ordering — learning that *this* operator consistently acts on
+young domains with mail capability and ignores parked ones, and floating the
+former to the top of a long list.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+import json
+import logging
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+from . import features
+from .features import FEATURE_NAMES
+
+MODEL_VERSION = 1
+MODEL_FILENAME = 'triage_model.json'
+
+logger = logging.getLogger(__name__)
+
+
+class TriageModel:
+    """A trained ranking model, loaded from JSON and scored in pure Python."""
+
+    def __init__(self, payload: dict[str, Any]):
+        self.feature_names: list[str] = list(payload.get('feature_names') or [])
+        self.weights: list[float] = [float(w) for w in payload.get('weights') or []]
+        self.intercept: float = float(payload.get('intercept') or 0.0)
+        self.mean: list[float] = [float(m) for m in payload.get('mean') or []]
+        self.scale: list[float] = [float(s) for s in payload.get('scale') or []]
+        self.metadata: dict[str, Any] = payload.get('metadata') or {}
+
+    @property
+    def is_usable(self) -> bool:
+        """Whether this model matches the current feature definition."""
+        return (
+            len(self.weights) == len(self.feature_names) == len(self.mean)
+            == len(self.scale) == len(FEATURE_NAMES)
+            and self.feature_names == list(FEATURE_NAMES)
+        )
+
+    def score(self, perm: dict[str, Any], monitored_domain: str) -> float:
+        """
+        Rank one permutation.
+
+        Args:
+            perm: Permutation record
+            monitored_domain: The brand it was found against
+
+        Returns:
+            A value in [0, 1]: how much this resembles findings the operator
+            has acted on. It is a ranking aid, not a risk score.
+        """
+        vector = features.extract(perm, monitored_domain)
+
+        total = self.intercept
+        for value, mean, scale, weight in zip(
+            vector, self.mean, self.scale, self.weights, strict=True
+        ):
+            total += ((value - mean) / (scale or 1.0)) * weight
+
+        # Sigmoid, guarded against overflow on extreme inputs
+        if total >= 0:
+            return 1.0 / (1.0 + math.exp(-min(total, 60.0)))
+        exponent = math.exp(max(total, -60.0))
+        return exponent / (1.0 + exponent)
+
+    def explain(self, perm: dict[str, Any], monitored_domain: str, top: int = 5):
+        """
+        The features that moved this particular score the most.
+
+        Args:
+            perm: Permutation record
+            monitored_domain: The brand it was found against
+            top: How many contributions to return
+
+        Returns:
+            List of (feature_name, signed_contribution), largest magnitude first
+        """
+        vector = features.extract(perm, monitored_domain)
+        contributions = [
+            (name, ((value - mean) / (scale or 1.0)) * weight)
+            for name, value, mean, scale, weight in zip(
+                self.feature_names, vector, self.mean, self.scale, self.weights,
+                strict=True,
+            )
+        ]
+        contributions.sort(key=lambda pair: abs(pair[1]), reverse=True)
+        return contributions[:top]
+
+    def influential_features(self, top: int = 10):
+        """The features the model relies on overall, largest weight first."""
+        ranked = sorted(
+            zip(self.feature_names, self.weights, strict=False),
+            key=lambda pair: abs(pair[1]), reverse=True,
+        )
+        return ranked[:top]
+
+
+def model_path(state_dir: Path) -> Path:
+    """Where the trained model lives."""
+    return Path(state_dir) / MODEL_FILENAME
+
+
+def load(state_dir: Path) -> TriageModel | None:
+    """
+    Load the trained model, if one exists and matches the current features.
+
+    Args:
+        state_dir: Directory holding scan state
+
+    Returns:
+        A usable TriageModel, or None
+    """
+    path = model_path(state_dir)
+    if not path.exists():
+        return None
+
+    try:
+        with open(path, encoding='utf-8') as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(
+            f'Could not read the triage model ({type(e).__name__}); '
+            f'ranking will fall back to the risk score'
+        )
+        return None
+
+    model = TriageModel(payload)
+    if not model.is_usable:
+        # Features were added or reordered since training. Silently scoring
+        # with a mismatched vector would produce plausible nonsense.
+        logger.warning(
+            'The stored triage model was trained on a different feature set '
+            'and will not be used. Retrain with: typo_sniper.py --ml-train'
+        )
+        return None
+    return model
+
+
+def train(dataset, state_dir: Path) -> dict[str, Any]:
+    """
+    Fit a model on labelled history and write it as JSON.
+
+    Args:
+        dataset: Object with .vectors (list[list[float]]) and .targets (list[int])
+        state_dir: Where to write the model
+
+    Returns:
+        A report describing the fit, including a cross-validated score
+
+    Raises:
+        ImportError: If scikit-learn is not installed
+    """
+    import numpy as np
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.model_selection import StratifiedKFold, cross_val_score
+    from sklearn.preprocessing import StandardScaler
+
+    x = np.asarray(dataset.vectors, dtype=float)
+    y = np.asarray(dataset.targets, dtype=int)
+
+    scaler = StandardScaler().fit(x)
+    x_scaled = scaler.transform(x)
+
+    # L2-regularised and class-balanced: label sets here are small and usually
+    # lopsided, since operators record the domains they acted on far more
+    # reliably than the ones they waved past.
+    # L2 is lbfgs's default across every supported scikit-learn version;
+    # passing penalty= explicitly is deprecated from 1.8 on.
+    estimator = LogisticRegression(
+        C=1.0, class_weight='balanced', max_iter=2000, solver='lbfgs',
+    )
+
+    # Cross-validated before fitting on everything, so the reported score is
+    # not the training score. On a small label set that difference is the
+    # whole story.
+    folds = max(2, min(5, int(min(np.bincount(y)))))
+    try:
+        scores = cross_val_score(
+            estimator, x_scaled, y,
+            cv=StratifiedKFold(n_splits=folds, shuffle=True, random_state=0),
+            scoring='roc_auc',
+        )
+        cv_auc = float(scores.mean())
+        cv_std = float(scores.std())
+    except ValueError:
+        cv_auc, cv_std = float('nan'), float('nan')
+
+    estimator.fit(x_scaled, y)
+
+    payload = {
+        'version': MODEL_VERSION,
+        'feature_names': list(FEATURE_NAMES),
+        'weights': [float(w) for w in estimator.coef_[0]],
+        'intercept': float(estimator.intercept_[0]),
+        'mean': [float(m) for m in scaler.mean_],
+        'scale': [float(s) for s in scaler.scale_],
+        'metadata': {
+            'trained_at': time.time(),
+            'samples': len(y),
+            'acted': int((y == 1).sum()),
+            'dismissed': int((y == 0).sum()),
+            'cv_folds': folds,
+            'cv_roc_auc': cv_auc,
+            'cv_roc_auc_std': cv_std,
+            'monitored_domains': sorted(set(getattr(dataset, 'monitored_domains', []))),
+        },
+    }
+
+    path = model_path(state_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as handle:
+        json.dump(payload, handle, indent=2)
+
+    model = TriageModel(payload)
+    return {
+        'path': str(path),
+        'samples': payload['metadata']['samples'],
+        'acted': payload['metadata']['acted'],
+        'dismissed': payload['metadata']['dismissed'],
+        'cv_roc_auc': cv_auc,
+        'cv_roc_auc_std': cv_std,
+        'cv_folds': folds,
+        'influential_features': model.influential_features(),
+    }
+
+
+def sklearn_available() -> bool:
+    """Whether the training dependency is installed."""
+    import importlib.util
+    return importlib.util.find_spec('sklearn') is not None

--- a/src/typo_sniper.py
+++ b/src/typo_sniper.py
@@ -31,6 +31,7 @@ from ai import AIAnalyzer  # noqa: E402
 from cache import Cache  # noqa: E402
 from config import Config  # noqa: E402
 from exporters import CSVExporter, ExcelExporter, HTMLExporter, JSONExporter  # noqa: E402
+from ml import LabelStore  # noqa: E402
 from notifiers import dispatch, write_delta_json  # noqa: E402
 from scanner import DomainScanner  # noqa: E402
 from state import ScanHistory, summarize  # noqa: E402
@@ -60,6 +61,13 @@ class TypoSniper:
         self.deltas: list = []
         self.analyzer = AIAnalyzer(config)
         self.ai_results: list = []
+
+        # Loaded once. A missing or stale model is not an error: ranking falls
+        # back to the deterministic risk score, which is the default anyway.
+        self.triage_model = None
+        if config.enable_ml_ranking:
+            import ml
+            self.triage_model = ml.load(config.state_dir)
 
     def close(self) -> None:
         """Release the scanner's worker threads."""
@@ -136,6 +144,7 @@ class TypoSniper:
             
             try:
                 result = await self.scanner.scan_domain(domain)
+                self._apply_ml_ranking(result)
                 self.results.append(result)
 
                 # Diff against the previous scan before recording this one,
@@ -210,6 +219,49 @@ class TypoSniper:
             except Exception as e:
                 self.logger.error(f"Error exporting to {format_name}: {e}", exc_info=True)
                 console.print(f"[red]✗[/red] Error exporting to {format_name}: {e}")
+
+    def _apply_ml_ranking(self, result: dict) -> None:
+        """
+        Reorder one domain's findings using the trained model.
+
+        Risk scores are left exactly as computed. Only the order changes, plus
+        two added fields recording what the model thought and why — so a report
+        that was reordered says so, rather than presenting a different order
+        with no explanation.
+
+        Args:
+            result: Scan result for one monitored domain, modified in place
+        """
+        if self.triage_model is None:
+            return
+
+        monitored = result.get('original_domain', '')
+        permutations = result.get('permutations') or []
+
+        for perm in permutations:
+            try:
+                perm['ml_rank'] = round(
+                    self.triage_model.score(perm, monitored), 4
+                )
+                perm['ml_explain'] = [
+                    {'feature': name, 'contribution': round(value, 3)}
+                    for name, value in self.triage_model.explain(
+                        perm, monitored, self.config.ml_explain_top
+                    )
+                ]
+            except Exception as e:
+                # A scoring failure must not cost the finding. The scan's own
+                # output is complete without it.
+                self.logger.warning(
+                    f'Could not rank {perm.get("domain")}: {type(e).__name__}'
+                )
+                perm['ml_rank'] = None
+
+        # Unranked findings sort last rather than to the top with a 0
+        permutations.sort(
+            key=lambda p: (p.get('ml_rank') is not None, p.get('ml_rank') or 0.0),
+            reverse=True,
+        )
 
     def print_summary(self) -> None:
         """Print a summary of scan results."""
@@ -587,6 +639,34 @@ Examples:
     )
 
     parser.add_argument(
+        '--label',
+        action='append',
+        metavar='DOMAIN=acted|dismissed',
+        default=None,
+        help='Record a judgement about a finding, then exit. Repeatable. '
+             "'acted' means worth acting on, 'dismissed' means reviewed and "
+             'not worth acting on; both are needed to train.'
+    )
+
+    parser.add_argument(
+        '--ml-train',
+        action='store_true',
+        help='Train the triage ranking model on labelled history, then exit'
+    )
+
+    parser.add_argument(
+        '--ml-status',
+        action='store_true',
+        help='Report label counts and the trained model, then exit'
+    )
+
+    parser.add_argument(
+        '--ml-rank',
+        action='store_true',
+        help='Order findings by the trained model. Risk scores are unchanged.'
+    )
+
+    parser.add_argument(
         '--secrets-check',
         action='store_true',
         help='Report which secrets backends are reachable and where each '
@@ -620,6 +700,187 @@ Examples:
     )
 
     return parser.parse_args()
+
+
+def apply_labels(config, specs: list[str]) -> int:
+    """
+    Record operator judgements about findings.
+
+    Args:
+        config: Configuration object
+        specs: Strings of the form ``domain=acted`` or ``domain=dismissed``
+
+    Returns:
+        Process exit code
+    """
+    from ml.labels import VALID_LABELS
+
+    store = LabelStore(config.state_dir)
+    failures = 0
+
+    for spec in specs:
+        domain, _, label = spec.partition('=')
+        domain, label = domain.strip(), label.strip().lower()
+
+        if not label:
+            console.print(
+                f"[red]✗[/red] '{spec}': expected DOMAIN=acted or DOMAIN=dismissed"
+            )
+            failures += 1
+            continue
+
+        try:
+            store.set(domain, label)
+        except ValueError as e:
+            console.print(f'[red]✗[/red] {e}')
+            failures += 1
+            continue
+
+        console.print(f'[green]✓[/green] {domain} labelled [bold]{label}[/bold]')
+
+    ready, reason = store.readiness()
+    marker = '[green]✓[/green]' if ready else '[yellow]•[/yellow]'
+    console.print(f'\n{marker} {reason}')
+    if not ready:
+        console.print(
+            f'[dim]Valid labels: {", ".join(VALID_LABELS)}. Both are needed — a '
+            f'model cannot learn a boundary from one side of it.[/dim]'
+        )
+    return 1 if failures else 0
+
+
+def print_ml_status(config, domains: list[str] | None = None) -> None:
+    """
+    Report what the learned-triage layer currently has to work with.
+
+    Args:
+        config: Configuration object
+        domains: Monitored domains whose history should be counted
+    """
+    import ml
+    from ml.model import model_path
+
+    store = LabelStore(config.state_dir)
+    counts = store.counts()
+    ready, reason = store.readiness()
+
+    console.print('\n[bold]Labels[/bold]')
+    console.print(f"  acted:     {counts.get('acted', 0)}")
+    console.print(f"  dismissed: {counts.get('dismissed', 0)}")
+    marker = '[green]✓[/green]' if ready else '[yellow]•[/yellow]'
+    console.print(f'  {marker} {reason}')
+
+    console.print('\n[bold]Model[/bold]')
+    model = ml.load(config.state_dir)
+    if model is None:
+        exists = model_path(config.state_dir).exists()
+        console.print(
+            '  [yellow]none trained[/yellow]'
+            if not exists else
+            '  [yellow]present but unusable — retrain with --ml-train[/yellow]'
+        )
+    else:
+        meta = model.metadata
+        auc = meta.get('cv_roc_auc')
+        console.print(f"  trained on {meta.get('samples', 0)} labels "
+                      f"({meta.get('acted', 0)} acted, {meta.get('dismissed', 0)} dismissed)")
+        if isinstance(auc, (int, float)) and auc == auc:  # not NaN
+            console.print(f"  cross-validated ROC AUC: {auc:.3f} "
+                          f"(±{meta.get('cv_roc_auc_std', 0):.3f}, "
+                          f"{meta.get('cv_folds', 0)} folds)")
+        console.print('  [bold]most influential features[/bold]')
+        for name, weight in model.influential_features(6):
+            console.print(f'    {name:<26} {weight:+.3f}')
+
+    if domains:
+        history = ScanHistory(config.state_dir, config.history_retain)
+        dataset = ml.build(history, store, domains)
+        console.print(f'\n[bold]Training set[/bold]\n  {len(dataset)} labelled '
+                      f'domain(s) matched to scan history')
+        if dataset.unmatched:
+            console.print(f'  [yellow]{len(dataset.unmatched)} labelled domain(s) '
+                          f'have no retained history and cannot be used[/yellow]')
+
+    console.print(
+        '\n[dim]The model ranks findings; it does not score them. Risk scores '
+        'stay deterministic so a takedown request can cite them.[/dim]\n'
+    )
+
+
+def run_ml_training(config, domains: list[str]) -> int:
+    """
+    Train the ranking model on labelled history.
+
+    Args:
+        config: Configuration object
+        domains: Monitored domains whose history holds the labelled findings
+
+    Returns:
+        Process exit code
+    """
+    import ml
+
+    if not ml.sklearn_available():
+        console.print(
+            '[red]✗[/red] Training needs scikit-learn, which is not installed.\n'
+            '  [dim]pip install -e ".[ml]"[/dim]\n'
+            '  [dim]Only training needs it. Scoring is pure Python, so hosts '
+            'that run scans do not.[/dim]'
+        )
+        return 1
+
+    store = LabelStore(config.state_dir)
+    ready, reason = store.readiness()
+    if not ready:
+        console.print(f'[yellow]•[/yellow] Not enough labelled data yet: {reason}')
+        return 1
+
+    history = ScanHistory(config.state_dir, config.history_retain)
+    dataset = ml.build(history, store, domains)
+
+    if len(dataset) < config.ml_min_labels:
+        console.print(
+            f'[yellow]•[/yellow] Only {len(dataset)} labelled domain(s) matched '
+            f'scan history, below the {config.ml_min_labels} required.'
+        )
+        if dataset.unmatched:
+            console.print(
+                f'  [dim]{len(dataset.unmatched)} label(s) refer to domains with '
+                f'no retained history.[/dim]'
+            )
+        return 1
+
+    counts = dataset.class_counts
+    if not counts['acted'] or not counts['dismissed']:
+        console.print(
+            '[yellow]•[/yellow] The matched labels are all one class. A model '
+            'needs examples of both to learn where the boundary is.'
+        )
+        return 1
+
+    console.print(f'\n[bold]Training on {len(dataset)} labelled findings[/bold] '
+                  f"({counts['acted']} acted, {counts['dismissed']} dismissed)")
+
+    report = ml.train(dataset, config.state_dir)
+
+    auc = report['cv_roc_auc']
+    console.print(f"[green]✓[/green] Model written to {report['path']}")
+    if auc == auc:  # not NaN
+        console.print(f"  cross-validated ROC AUC: {auc:.3f} "
+                      f"(±{report['cv_roc_auc_std']:.3f} over {report['cv_folds']} folds)")
+        if auc < 0.65:
+            console.print(
+                '  [yellow]That is close to guessing. More labels, or labels '
+                'that disagree with the risk score more often, would help.[/yellow]'
+            )
+    console.print('\n  [bold]most influential features[/bold]')
+    for name, weight in report['influential_features'][:8]:
+        console.print(f'    {name:<26} {weight:+.3f}')
+    console.print(
+        '\n[dim]Run a scan with --ml-rank to order findings by this model. '
+        'Risk scores are unaffected.[/dim]\n'
+    )
+    return 0
 
 
 def print_secrets_check(config) -> None:
@@ -744,6 +1005,15 @@ async def main():
         print_secrets_check(config)
         return
 
+    if args.ml_rank:
+        config.enable_ml_ranking = True
+
+    if args.label:
+        code = apply_labels(config, args.label)
+        if code:
+            sys.exit(code)
+        return
+
     # Override config with command-line arguments
     config.max_workers = args.max_workers
     config.cache_ttl = args.cache_ttl
@@ -788,6 +1058,18 @@ async def main():
             sniper.close()
             sys.exit(1)
 
+        if args.ml_status:
+            print_ml_status(config, domains)
+            sniper.close()
+            return
+
+        if args.ml_train:
+            code = run_ml_training(config, domains)
+            sniper.close()
+            if code:
+                sys.exit(code)
+            return
+
         console.print(f"[bold]Domains to scan:[/bold] {len(domains)}")
         console.print(f"[bold]Output formats:[/bold] {', '.join(args.format)}")
         console.print(f"[bold]Cache enabled:[/bold] {'Yes' if config.use_cache else 'No'}")
@@ -807,6 +1089,12 @@ async def main():
             console.print(
                 "[bold]AI triage:[/bold] "
                 + (config.ai_provider if ready else f"[yellow]unavailable ({reason})[/yellow]")
+            )
+        if config.enable_ml_ranking:
+            console.print(
+                '[bold]Ranking:[/bold] '
+                + ('learned triage model' if sniper.triage_model
+                   else '[yellow]no usable model; using risk score[/yellow]')
             )
         if args.months > 0:
             console.print(

--- a/src/version.py
+++ b/src/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"

--- a/tests/unit/test_ml_features.py
+++ b/tests/unit/test_ml_features.py
@@ -1,0 +1,197 @@
+"""
+Tests for feature extraction.
+
+Two properties matter more than any individual feature and are asserted
+throughout: extraction is deterministic, and a vector built from a history
+snapshot is identical to one built from the live scan record it came from.
+A model trained on the second and scoring the first would be quietly wrong.
+"""
+
+import math
+
+import pytest
+
+from ml import features
+from ml.features import FEATURE_COUNT, FEATURE_NAMES, extract
+
+
+def perm(**overrides):
+    base = {
+        'domain': 'examp1e.com',
+        'fuzzer': 'homoglyph',
+        'risk_score': 70,
+        'created_days_ago': 10,
+        'dns_a': ['203.0.113.1'],
+        'dns_mx': [],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestVectorShape:
+    def test_length_matches_the_declared_names(self):
+        assert len(extract(perm(), 'example.com')) == FEATURE_COUNT
+        assert len(FEATURE_NAMES) == FEATURE_COUNT
+
+    def test_names_are_unique(self):
+        assert len(set(FEATURE_NAMES)) == len(FEATURE_NAMES)
+
+    def test_extraction_is_deterministic(self):
+        assert extract(perm(), 'example.com') == extract(perm(), 'example.com')
+
+    def test_every_value_is_finite(self):
+        vector = extract(perm(), 'example.com')
+        assert all(math.isfinite(v) for v in vector)
+
+    def test_values_are_bounded(self):
+        """Unbounded features let one outlier dominate a linear model."""
+        extreme = perm(
+            domain='a' * 63 + '.com', risk_score=10_000,
+            created_days_ago=10_000_000, dns_a=['1.2.3.4'] * 50,
+            dns_mx=['mx'] * 50, certificates_found=10 ** 9,
+        )
+        assert all(0.0 <= v <= 1.0 for v in extract(extreme, 'example.com'))
+
+    def test_empty_record_does_not_crash(self):
+        assert len(extract({}, 'example.com')) == FEATURE_COUNT
+
+    def test_missing_monitored_domain_does_not_crash(self):
+        assert len(extract(perm(), '')) == FEATURE_COUNT
+
+
+class TestSnapshotEquivalence:
+    """A history snapshot must produce the same vector as the live record."""
+
+    def test_http_fields_read_from_either_shape(self):
+        live = perm(threat_intel={'http_probe': {
+            'http_active': True, 'https_active': True,
+            'tls_verified': True, 'title': 'Sign in',
+        }})
+        snapshot = perm(
+            http_active=True, https_active=True,
+            tls_verified=True, title='Sign in',
+        )
+        assert extract(live, 'example.com') == extract(snapshot, 'example.com')
+
+    def test_mail_posture_reads_from_either_shape(self):
+        live = perm(mail_intel={'posture': 'hardened'})
+        snapshot = perm(mail_posture='hardened')
+        assert extract(live, 'example.com') == extract(snapshot, 'example.com')
+
+    def test_certificates_read_from_either_shape(self):
+        live = perm(threat_intel={'certificate_transparency': {'certificates_found': 12}})
+        snapshot = perm(certificates_found=12)
+        assert extract(live, 'example.com') == extract(snapshot, 'example.com')
+
+    def test_urlscan_reads_from_either_shape(self):
+        live = perm(threat_intel={'urlscan': {'malicious': True}})
+        snapshot = perm(urlscan_malicious=True)
+        assert extract(live, 'example.com') == extract(snapshot, 'example.com')
+
+
+def value(record, name, monitored='example.com'):
+    return dict(zip(FEATURE_NAMES, extract(record, monitored), strict=True))[name]
+
+
+class TestSignals:
+    def test_dns_sentinels_are_not_counted_as_records(self):
+        """!ServFail is a failed lookup, not an address."""
+        assert value(perm(dns_a=['!ServFail']), 'has_a_record') == 0.0
+        assert value(perm(dns_a=['!NXDOMAIN']), 'has_a_record') == 0.0
+        assert value(perm(dns_a=['203.0.113.1']), 'has_a_record') == 1.0
+
+    def test_a_failed_mail_lookup_scores_as_absent_not_as_evidence(self):
+        assert value(perm(mail_posture='unknown'), 'mail_posture') == 0.0
+        assert value(perm(mail_posture='none'), 'mail_posture') == 0.0
+        assert value(perm(mail_posture='hardened'), 'mail_posture') == 1.0
+
+    def test_mail_posture_is_ordered_by_deliberate_effort(self):
+        postures = ['none', 'receive-only', 'partial', 'provisioned', 'hardened']
+        scores = [value(perm(mail_posture=p), 'mail_posture') for p in postures]
+        assert scores == sorted(scores)
+
+    def test_younger_domains_score_higher(self):
+        young = value(perm(created_days_ago=2), 'age_days_log')
+        old = value(perm(created_days_ago=3000), 'age_days_log')
+        assert young > old
+
+    def test_unknown_age_is_not_treated_as_brand_new(self):
+        assert value(perm(created_days_ago=None), 'age_days_log') == 0.0
+
+    def test_invalid_tls_is_distinct_from_no_https(self):
+        """A host answering on 443 with a bad certificate is its own state."""
+        bad = perm(https_active=True, tls_verified=False)
+        absent = perm(https_active=False, tls_verified=None)
+        assert value(bad, 'tls_invalid') == 1.0
+        assert value(absent, 'tls_invalid') == 0.0
+        assert value(bad, 'tls_verified') == 0.0
+
+    def test_credential_words_in_titles(self):
+        assert value(perm(title='Sign in to your account'),
+                     'title_credential_words') > 0
+        assert value(perm(title='Acme Widgets'), 'title_credential_words') == 0
+
+    def test_parked_pages_are_recognised(self):
+        assert value(perm(title='This domain is for sale'),
+                     'title_parked_words') > 0
+
+    def test_punycode_is_flagged(self):
+        assert value(perm(domain='xn--e1awd7f.com'), 'is_punycode') == 1.0
+        assert value(perm(domain='example.com'), 'is_punycode') == 0.0
+
+    def test_private_registrant_is_detected(self):
+        for text in ('REDACTED FOR PRIVACY', 'Whois Guard', 'Data Protected'):
+            assert value(perm(whois_registrant=text), 'registrant_is_private') == 1.0
+        assert value(perm(whois_registrant='Acme Ltd'), 'registrant_is_private') == 0.0
+
+    def test_brand_containment_is_detected(self):
+        assert value(perm(domain='example-login.com'), 'shares_registrable_stem') == 1.0
+        assert value(perm(domain='wholly-unrelated.com'), 'shares_registrable_stem') == 0.0
+
+    def test_tld_match(self):
+        assert value(perm(domain='example.com'), 'tld_matches_brand') == 1.0
+        assert value(perm(domain='example.xyz'), 'tld_matches_brand') == 0.0
+
+
+class TestEditDistance:
+    @pytest.mark.parametrize('a,b,expected', [
+        ('example', 'example', 0),
+        ('example', 'examp1e', 1),
+        ('example', 'exemple', 1),
+        ('example', 'exampl', 1),
+        ('', 'abc', 3),
+        ('abc', '', 3),
+        ('kitten', 'sitting', 3),
+    ])
+    def test_distances(self, a, b, expected):
+        assert features._edit_distance(a, b) == expected
+
+    def test_ratio_accounts_for_brand_length(self):
+        """One edit in a short name is a bigger change than in a long one."""
+        short = value(perm(domain='acmr.com'), 'edit_distance_ratio', 'acme.com')
+        long = value(perm(domain='internationalbusines.com'),
+                     'edit_distance_ratio', 'internationalbusiness.com')
+        assert short > long
+
+
+class TestEntropy:
+    def test_uniform_string_has_no_entropy(self):
+        assert features._entropy('aaaa') == 0.0
+
+    def test_empty_string(self):
+        assert features._entropy('') == 0.0
+
+    def test_varied_string_has_more(self):
+        assert features._entropy('abcd') > features._entropy('aaab')
+
+
+class TestNormaliseDomain:
+    @pytest.mark.parametrize('given,expected', [
+        ('Example.COM', 'example.com'),
+        ('  example.com  ', 'example.com'),
+        ('example.com.', 'example.com'),
+        ('.example.com', 'example.com'),
+        (None, ''),
+    ])
+    def test_canonical_form(self, given, expected):
+        assert features.normalise_domain(given) == expected

--- a/tests/unit/test_ml_labels.py
+++ b/tests/unit/test_ml_labels.py
@@ -1,0 +1,115 @@
+"""Tests for the operator label store."""
+
+import json
+
+import pytest
+
+from ml.labels import (
+    ACTED,
+    DISMISSED,
+    MIN_LABELS_TO_TRAIN,
+    MIN_PER_CLASS,
+    LabelStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LabelStore(tmp_path)
+
+
+class TestStoringLabels:
+    def test_round_trip(self, store):
+        store.set('evil.com', ACTED, 'example.com')
+        assert store.get('evil.com') == ACTED
+
+    def test_domain_matching_is_canonical(self, store):
+        store.set('  Evil.COM.  ', ACTED)
+        assert store.get('evil.com') == ACTED
+        assert store.get('EVIL.com') == ACTED
+
+    def test_unknown_label_is_rejected(self, store):
+        with pytest.raises(ValueError, match='Unknown label'):
+            store.set('evil.com', 'maybe')
+
+    def test_a_label_needs_a_domain(self, store):
+        with pytest.raises(ValueError, match='needs a domain'):
+            store.set('', ACTED)
+
+    def test_relabelling_keeps_the_previous_judgement(self, store):
+        """A changed decision should be visible, not silently overwritten."""
+        store.set('evil.com', ACTED)
+        store.set('evil.com', DISMISSED)
+        entry = store.all()['evil.com']
+        assert entry['label'] == DISMISSED
+        assert entry['previous_label'] == ACTED
+
+    def test_notes_are_bounded(self, store):
+        store.set('evil.com', ACTED, note='x' * 5000)
+        assert len(store.all()['evil.com']['note']) <= 500
+
+    def test_removal(self, store):
+        store.set('evil.com', ACTED)
+        assert store.remove('evil.com') is True
+        assert store.get('evil.com') is None
+        assert store.remove('evil.com') is False
+
+    def test_persists_across_instances(self, tmp_path):
+        LabelStore(tmp_path).set('evil.com', ACTED)
+        assert LabelStore(tmp_path).get('evil.com') == ACTED
+
+
+class TestResilience:
+    def test_corrupt_file_does_not_stop_a_scan(self, tmp_path, caplog):
+        """Labels are training data; losing them must not fail the run."""
+        (tmp_path / 'labels.json').write_text('{ not json')
+        store = LabelStore(tmp_path)
+        assert store.all() == {}
+        assert 'labels' in caplog.text.lower()
+
+    def test_entries_with_invalid_labels_are_dropped(self, tmp_path):
+        (tmp_path / 'labels.json').write_text(json.dumps({
+            'labels': {
+                'good.com': {'label': ACTED},
+                'bad.com': {'label': 'nonsense'},
+                'malformed.com': 'not a dict',
+            }
+        }))
+        assert set(LabelStore(tmp_path).all()) == {'good.com'}
+
+    def test_missing_file_is_not_an_error(self, tmp_path):
+        assert LabelStore(tmp_path / 'nope').all() == {}
+
+
+class TestReadiness:
+    def _fill(self, store, acted, dismissed):
+        for i in range(acted):
+            store.set(f'a{i}.com', ACTED)
+        for i in range(dismissed):
+            store.set(f'd{i}.com', DISMISSED)
+
+    def test_not_ready_when_empty(self, store):
+        ready, reason = store.readiness()
+        assert ready is False
+        assert str(MIN_LABELS_TO_TRAIN) in reason
+
+    def test_not_ready_with_only_one_class(self, store):
+        self._fill(store, MIN_LABELS_TO_TRAIN + 5, 0)
+        ready, reason = store.readiness()
+        assert ready is False
+        assert 'one side of it' in reason
+
+    def test_not_ready_when_a_class_is_too_thin(self, store):
+        self._fill(store, MIN_LABELS_TO_TRAIN, MIN_PER_CLASS - 1)
+        ready, _ = store.readiness()
+        assert ready is False
+
+    def test_ready_with_a_balanced_set(self, store):
+        self._fill(store, MIN_LABELS_TO_TRAIN, MIN_LABELS_TO_TRAIN)
+        ready, reason = store.readiness()
+        assert ready is True
+        assert 'acted' in reason and 'dismissed' in reason
+
+    def test_counts(self, store):
+        self._fill(store, 3, 2)
+        assert store.counts() == {ACTED: 3, DISMISSED: 2}

--- a/tests/unit/test_ml_model.py
+++ b/tests/unit/test_ml_model.py
@@ -1,0 +1,238 @@
+"""
+Tests for dataset assembly and the trained model.
+
+The property this file exists for: a model file is data, never code. Scoring
+loads JSON and does arithmetic. Nothing here unpickles anything, because model
+files get emailed around and committed, and pickle.load is arbitrary code
+execution.
+"""
+
+import importlib.util
+import json
+
+import pytest
+
+import ml
+from ml import build
+from ml.features import FEATURE_NAMES
+from ml.labels import ACTED, DISMISSED, LabelStore
+from ml.model import TriageModel, model_path
+from state import ScanHistory
+
+sklearn_missing = importlib.util.find_spec('sklearn') is None
+needs_sklearn = pytest.mark.skipif(
+    sklearn_missing, reason='training needs scikit-learn; scoring does not'
+)
+
+
+def make_perm(domain, *, bad, **extra):
+    record = {
+        'domain': domain,
+        'fuzzer': 'combosquat',
+        'risk_score': 85 if bad else 15,
+        'created_days_ago': 5 if bad else 2500,
+        'dns_a': ['203.0.113.1'] if bad else [],
+        'dns_mx': ['mx.test'] if bad else [],
+        'whois_registrant': 'REDACTED FOR PRIVACY' if bad else 'Acme Ltd',
+        # The nested shape a live scan produces, so records written to history
+        # exercise the same flattening the scanner's do.
+        'mail_intel': {'posture': 'provisioned' if bad else 'none'},
+        'threat_intel': {'http_probe': {
+            'http_active': bad,
+            'https_active': bad,
+            'tls_verified': True,
+            'title': 'Sign in to your account' if bad else 'Domain for sale',
+        }},
+    }
+    record.update(extra)
+    return record
+
+
+def seeded(tmp_path, count=40):
+    """A history and label set with a learnable separation."""
+    history = ScanHistory(tmp_path)
+    store = LabelStore(tmp_path)
+    perms = []
+    for i in range(count):
+        bad = i % 2 == 0
+        domain = f'{"secure-example" if bad else "exampleparts"}{i}.com'
+        perms.append(make_perm(domain, bad=bad))
+        store.set(domain, ACTED if bad else DISMISSED, 'example.com')
+    history.record({
+        'original_domain': 'example.com', 'scan_date': '2026-08-01',
+        'registered_count': count, 'permutations': perms,
+    })
+    return history, store
+
+
+class TestDatasetAssembly:
+    def test_labels_join_to_history(self, tmp_path):
+        history, store = seeded(tmp_path, 10)
+        dataset = build(history, store, ['example.com'])
+        assert len(dataset) == 10
+        assert dataset.class_counts == {'acted': 5, 'dismissed': 5}
+
+    def test_labels_without_history_are_reported_not_silently_dropped(self, tmp_path):
+        history, store = seeded(tmp_path, 4)
+        store.set('never-scanned.com', ACTED)
+        dataset = build(history, store, ['example.com'])
+        assert dataset.unmatched == ['never-scanned.com']
+        assert len(dataset) == 4
+
+    def test_features_come_from_the_earliest_snapshot(self, tmp_path):
+        """
+        The bug this guards against: a domain that has since been taken down
+        resolves nowhere today. Training on its current state would teach the
+        model that dead domains are the dangerous ones — an inversion learned
+        from perfectly good labels.
+        """
+        history = ScanHistory(tmp_path)
+        store = LabelStore(tmp_path)
+
+        # First scan: live and dangerous. This is the state that was judged.
+        history.record({
+            'original_domain': 'example.com', 'scan_date': '2026-01-01',
+            'permutations': [make_perm('evil.com', bad=True)],
+        })
+        # Later scan: taken down, resolving nowhere.
+        history.record({
+            'original_domain': 'example.com', 'scan_date': '2026-06-01',
+            'permutations': [make_perm('evil.com', bad=False)],
+        })
+        store.set('evil.com', ACTED, 'example.com')
+
+        dataset = build(history, store, ['example.com'])
+        vector = dict(zip(FEATURE_NAMES, dataset.vectors[0], strict=True))
+        assert vector['has_a_record'] == 1.0, 'used the taken-down state'
+        assert vector['mail_posture'] > 0.0
+
+    def test_no_labels_produces_an_empty_dataset(self, tmp_path):
+        history, _ = seeded(tmp_path, 4)
+        # A separate directory, so this store genuinely holds no labels
+        assert len(build(history, LabelStore(tmp_path / 'empty'), ['example.com'])) == 0
+
+
+class TestScoringWithoutSklearn:
+    """The scoring path must work on a host with no ML dependencies."""
+
+    def _model(self, weights=None):
+        n = len(FEATURE_NAMES)
+        return TriageModel({
+            'feature_names': list(FEATURE_NAMES),
+            'weights': weights or [0.1] * n,
+            'intercept': 0.0,
+            'mean': [0.0] * n,
+            'scale': [1.0] * n,
+        })
+
+    def test_score_is_a_probability(self, tmp_path):
+        score = self._model().score(make_perm('evil.com', bad=True), 'example.com')
+        assert 0.0 <= score <= 1.0
+
+    def test_extreme_weights_do_not_overflow(self):
+        n = len(FEATURE_NAMES)
+        huge = TriageModel({
+            'feature_names': list(FEATURE_NAMES), 'weights': [1e6] * n,
+            'intercept': 1e9, 'mean': [0.0] * n, 'scale': [1.0] * n,
+        })
+        tiny = TriageModel({
+            'feature_names': list(FEATURE_NAMES), 'weights': [-1e6] * n,
+            'intercept': -1e9, 'mean': [0.0] * n, 'scale': [1.0] * n,
+        })
+        perm = make_perm('evil.com', bad=True)
+        assert huge.score(perm, 'example.com') == pytest.approx(1.0)
+        assert tiny.score(perm, 'example.com') == pytest.approx(0.0)
+
+    def test_zero_scale_does_not_divide_by_zero(self):
+        """A constant feature in the training set has zero variance."""
+        n = len(FEATURE_NAMES)
+        model = TriageModel({
+            'feature_names': list(FEATURE_NAMES), 'weights': [0.1] * n,
+            'intercept': 0.0, 'mean': [0.0] * n, 'scale': [0.0] * n,
+        })
+        assert 0.0 <= model.score(make_perm('evil.com', bad=True), 'example.com') <= 1.0
+
+    def test_explain_returns_signed_contributions(self):
+        contributions = self._model().explain(
+            make_perm('evil.com', bad=True), 'example.com', top=4
+        )
+        assert len(contributions) == 4
+        assert all(isinstance(name, str) for name, _ in contributions)
+        # Ordered by magnitude
+        magnitudes = [abs(v) for _, v in contributions]
+        assert magnitudes == sorted(magnitudes, reverse=True)
+
+    def test_influential_features_are_ranked_by_weight(self):
+        weights = [0.0] * len(FEATURE_NAMES)
+        weights[FEATURE_NAMES.index('mail_posture')] = -5.0
+        top = self._model(weights).influential_features(1)
+        assert top[0][0] == 'mail_posture'
+
+
+class TestModelLoading:
+    def test_absent_model_is_not_an_error(self, tmp_path):
+        assert ml.load(tmp_path) is None
+
+    def test_corrupt_model_degrades_to_none(self, tmp_path, caplog):
+        model_path(tmp_path).write_text('{ not json')
+        assert ml.load(tmp_path) is None
+        assert 'model' in caplog.text.lower()
+
+    def test_a_model_from_a_different_feature_set_is_refused(self, tmp_path, caplog):
+        """Scoring a mismatched vector would produce plausible nonsense."""
+        model_path(tmp_path).write_text(json.dumps({
+            'feature_names': ['only', 'three', 'features'],
+            'weights': [1.0, 1.0, 1.0], 'intercept': 0.0,
+            'mean': [0.0] * 3, 'scale': [1.0] * 3,
+        }))
+        assert ml.load(tmp_path) is None
+        assert 'retrain' in caplog.text.lower()
+
+
+@needs_sklearn
+class TestTraining:
+    def test_learns_a_separable_problem(self, tmp_path):
+        history, store = seeded(tmp_path, 40)
+        report = ml.train(build(history, store, ['example.com']), tmp_path)
+
+        assert report['samples'] == 40
+        assert report['acted'] == 20
+        assert report['dismissed'] == 20
+        assert report['cv_roc_auc'] > 0.9
+
+    def test_the_written_model_is_json_not_a_pickle(self, tmp_path):
+        """A model file is data. pickle.load on one is code execution."""
+        history, store = seeded(tmp_path, 40)
+        ml.train(build(history, store, ['example.com']), tmp_path)
+
+        raw = model_path(tmp_path).read_text()
+        payload = json.loads(raw)  # would raise if it were a pickle
+        assert set(payload) >= {'feature_names', 'weights', 'intercept',
+                                'mean', 'scale', 'metadata'}
+        assert payload['feature_names'] == list(FEATURE_NAMES)
+
+    def test_a_trained_model_ranks_the_dangerous_side_higher(self, tmp_path):
+        history, store = seeded(tmp_path, 40)
+        ml.train(build(history, store, ['example.com']), tmp_path)
+        model = ml.load(tmp_path)
+
+        dangerous = model.score(make_perm('secure-example99.com', bad=True), 'example.com')
+        benign = model.score(make_perm('exampleparts99.com', bad=False), 'example.com')
+        assert dangerous > benign
+
+    def test_metadata_records_what_it_was_trained_on(self, tmp_path):
+        history, store = seeded(tmp_path, 40)
+        ml.train(build(history, store, ['example.com']), tmp_path)
+
+        meta = ml.load(tmp_path).metadata
+        assert meta['samples'] == 40
+        assert meta['monitored_domains'] == ['example.com']
+        assert meta['trained_at'] > 0
+
+    def test_round_trip_scoring_matches_across_a_reload(self, tmp_path):
+        history, store = seeded(tmp_path, 40)
+        ml.train(build(history, store, ['example.com']), tmp_path)
+        perm = make_perm('evil.com', bad=True)
+        assert ml.load(tmp_path).score(perm, 'example.com') == pytest.approx(
+            ml.load(tmp_path).score(perm, 'example.com')
+        )


### PR DESCRIPTION
The risk score orders findings by a formula that is identical for everyone — but teams differ in what they act on. A bank cares most about mail capability, because that is the prerequisite for the wire-fraud email. A consumer SaaS cares most about a cloned login page. A game studio may ignore both and care about fake key sales.

This learns that difference from the operator's own past decisions and reorders findings accordingly. Optional, off by default, strictly additive.

---

## The model ranks. It never scores.

Risk scores are unchanged whether this is on or off, and remain the number that appears in reports and takedown requests. Same rule as the AI layer in #28, for the same reason:

> A registrar can check *"registered nine days ago, valid SPF and DKIM, serving a login page."*
> A registrar cannot check *"our model put it first."*

What the model changes is the **order** of a list a human reads, and which findings surface at the top of a long report.

## Model files are JSON and are never unpickled

`pickle.load` on a model file is arbitrary code execution, and model files get emailed between colleagues and committed to repositories. A trained model here is stored as feature names, weights, intercept, and standardisation constants — and scoring is a dot product and a sigmoid in pure Python.

Three things follow:

- **Scanning hosts install nothing.** Only whoever trains needs `.[ml]`.
- **The model is auditable.** Open it and read that `mail_posture` carries +1.2 and `title_parked_words` carries −0.8. For a tool whose output justifies takedown requests, "why is this first?" needs an answer.
- **Nothing executes on load.**

That is why this is logistic regression rather than a boosted ensemble that would likely score a point or two higher. An opaque model would trade away *both* the explanation and the safety property — to reorder a list a human reads either way.

## Labelling

```bash
python src/typo_sniper.py --label secure-example-login.com=acted
python src/typo_sniper.py --label example-fanclub.com=dismissed
python src/typo_sniper.py -i domains.txt --ml-status
python src/typo_sniper.py -i domains.txt --ml-train    # needs .[ml]
python src/typo_sniper.py -i domains.txt --ml-rank
```

**`dismissed` is first-class and training refuses without it.** A model trained only on confirmed-bad examples learns that everything is bad. Training also refuses below **30 labels total** and **8 of each class** — below that a model fits noise, and a confidently wrong ranking is worse than no ranking because it looks like signal. `--ml-status` reports exactly what is still missing.

Training reports a **cross-validated** ROC AUC, not a training score. On a forty-label set, the difference between those two numbers is the whole story.

There is deliberately **no pre-trained model shipped**. One would encode some other organisation's idea of what matters — the exact thing this feature exists to replace.

## Features come from the *earliest* snapshot

Each label is matched against the oldest retained scan that saw the domain, not the newest.

A domain you successfully had taken down resolves nowhere today. Matching labels to *current* state would teach the model that **dead domains are the dangerous ones** — an inversion of the truth, learned from perfectly good labels, that would then rank every parked domain above every live one. There's a test that asserts this directly.

34 features, all deterministic and all traceable to a field a human can look at: lexical, relational (edit distance scaled by brand length), DNS, registration age (log-scaled), mail posture, TLS validity, page content, and the deterministic risk score itself. The risk score is included as a *feature* rather than replaced — it encodes expert judgement forty labels cannot rediscover, so the model starts from it and learns adjustments.

Two details carried over from earlier work in this project: a failed lookup is not evidence (`mail_posture: unknown` scores as absent, DNS `!ServFail` sentinels are not counted as records), and age is log-scaled because 3 vs 30 days matters far more than 1000 vs 1027.

## Two bugs the tests caught

- **The risk-score feature was scaled but not clamped.** An out-of-range value from a stale record would have dominated every weight in a linear model. Found by a bounds assertion over the whole feature vector, not by inspection.
- **A model trained on an older feature set is now refused**, with a retrain message, rather than silently scoring a mismatched vector and producing plausible nonsense.

## Failure behaviour

Additive-only throughout. No model → order by risk score, as before. Stale model → refused with a retrain message. Corrupt model file → logged and ignored. Scoring throws on one finding → that finding sorts last and keeps every deterministic field. **No path loses a finding or changes a risk score.**

## Verification

- **555 tests pass** (up from 483), `ruff check src/ tests/` clean
- 72 new tests: feature extraction (determinism, bounds, live-vs-snapshot equivalence), the label store (persistence, corruption tolerance, readiness gates), dataset assembly (including the earliest-snapshot property), and the model (JSON-not-pickle, overflow guards, stale-model refusal)
- `scikit-learn` added to `requirements-dev.txt` so **CI exercises the training path** rather than skipping it; the training tests are `skipif`-guarded so the suite still passes without it
- Exercised end-to-end through the CLI: label → status → train → inspect the JSON model → score
- CI's smoke test reproduced locally (`config.yaml.example` loads, `--version`, `--help`)

## Not verified in this environment

The synthetic data I trained against is perfectly separable, so the ROC AUC of 1.000 in my local run is a smoke-test artifact and means nothing about real performance. **This feature cannot be meaningfully evaluated until it has real labels from real triage.** The first honest signal will be your own `--ml-status` after thirty-odd genuine decisions — and an unremarkable AUC near 0.5–0.6 there would be a real result too, meaning your decisions already track the risk score and the model has nothing to add.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_