### PR TITLE
Add Teams, Matrix, and Jira channels (v1.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-08-27
+
+Completes the alerting channels, and adds ticketing as something distinct from
+alerting.
+
+### Added
+
+- **Microsoft Teams** alerts, as an Adaptive Card sent to a Power Automate
+  "When a Teams webhook request is received" trigger. That is the current path:
+  the older Office 365 connector, which took a MessageCard at an
+  `outlook.office.com` URL, has been retired by Microsoft.
+
+- **Matrix** alerts via the client-server API, with no SDK required. Two
+  details that matter: the access token is sent as a bearer header rather than
+  the deprecated `?access_token=` query parameter, which would put the
+  credential in the homeserver's request logs and in every proxy along the way;
+  and each send carries a fresh transaction ID, so a retried delivery is
+  idempotent at the homeserver instead of double-posting.
+
+- **Jira ticketing.** This is not another chat channel, and the difference
+  drives its design. A message is disposable; a ticket is state, and a
+  scheduled scan that opened a fresh ticket for the same lookalike every
+  morning would bury a queue within a week. So:
+
+  - **One issue per domain, not per scan.** A lookalike is tracked from
+    detection through takedown, which is the unit of work an analyst has.
+  - **Deduplicated by a deterministic label.** The project is searched for an
+    open issue carrying this domain's label before anything is created. A
+    closed issue stays closed — a domain that comes back raises a new ticket,
+    which is correct, because it genuinely is a new event.
+  - **Capped per run** (`jira_max_issues_per_run`, default 10). The first scan
+    of a well-known brand can surface hundreds of registered lookalikes, and
+    turning that into hundreds of tickets would be the most destructive thing
+    this tool could do to someone's backlog. What the cap drops is logged, and
+    stays in the report and the delta JSON.
+
+  Only new, escalated, and activated findings are ticketed. A resolved domain
+  is good news, not work.
+
+### Changed
+
+- Notifiers now share one request helper supporting any HTTP method and custom
+  headers, so Slack's POST and Matrix's PUT go through the same timeout,
+  error-handling, and logging path. `WebhookNotifier` keeps its own call
+  deliberately, because it sends operator-supplied headers verbatim.
+
+- Teams, Matrix, and Jira credentials resolve through the secrets backends like
+  every other credential, so none of them need to sit in `config.yaml`.
+
+### Fixed
+
+- **`aiohttp.BasicAuth` is deprecated and removed in aiohttp 4.0.** The Jira
+  Basic header is now built with the standard library, which works on every
+  aiohttp version and adds no dependency. Caught by running the notifier tests
+  with `-W error::DeprecationWarning` rather than by waiting for aiohttp 4.
+
 ## [1.5.0] - 2026-08-27
 
 Learned triage: the tool starts using your own past decisions to order what it

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 - [Contributing](#-contributing)
 - [AI-Assisted Triage](#-ai-assisted-triage) 🤖
 - [Learned Triage Ranking](#-learned-triage-ranking) 🧠
+- [Alerting and Ticketing](#-alerting-and-ticketing) 🔔
 - [Secrets Management](#-secrets-management) 🔐
 - [Testing & Verification](#-testing-and-verification)
 
@@ -61,6 +62,7 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 | **[Secrets Management](docs/guides/SECRETS_MANAGEMENT.md)** | 🔐 Complete secrets management guide | Choosing secrets solution, security |
 | **[AI Analysis](docs/guides/AI_ANALYSIS.md)** | 🤖 AI-assisted triage and its injection defences | Enabling `--ai`, choosing a provider |
 | **[ML Triage](docs/guides/ML_TRIAGE.md)** | 🧠 Learned ranking from your own decisions | Labelling findings, training a model |
+| **[Alerting](docs/guides/ALERTING.md)** | 🔔 Slack, Discord, Teams, Matrix, Jira, webhook, email | Wiring up notifications and tickets |
 | **[Docker Guide](docker/DOCKER.md)** | 🐳 Docker deployment guide | Container deployment |
 | **[Project Structure](PROJECT_STRUCTURE.md)** | 📁 Project organization details | Contributing, understanding codebase |
 
@@ -986,6 +988,49 @@ would teach the model that dead domains are the dangerous ones — an inversion
 learned from perfectly good labels.
 
 See **[ML Triage](docs/guides/ML_TRIAGE.md)** for the full guide.
+
+**[⬆ Back to Top](#-table-of-contents)**
+
+---
+
+## 🔔 Alerting and Ticketing
+
+Alerts fire on **changes**, never on the full result set. A daily scan that
+re-reported the same seventy lookalikes every morning gets ignored within a
+week; one that says "a new lookalike appeared three days ago and it has MX
+records" gets read.
+
+```bash
+python src/typo_sniper.py -i domains.txt --notify slack jira
+```
+
+| Channel | What it does |
+|---|---|
+| `slack` / `discord` | Block Kit message / severity-coloured embed |
+| `teams` | Adaptive Card via a Power Automate workflow |
+| `matrix` | Room message via the client-server API, no SDK |
+| `jira` | **One deduplicated ticket per domain** |
+| `webhook` / `email` | Raw JSON to any endpoint / SMTP |
+
+**Jira is ticketing, not alerting, and that changes the design.** A message is
+disposable; a ticket is state. A scheduled scan that opened a fresh ticket for
+the same lookalike every morning would bury a queue within a week. So it files
+**one issue per domain**, deduplicated by a deterministic label, and **caps
+creation per run** — the first scan of a well-known brand can surface hundreds
+of lookalikes, and turning that into hundreds of tickets would be the most
+destructive thing this tool could do to your backlog. What the cap drops is
+logged and stays in the report.
+
+**Teams uses Power Automate**, not the retired Office 365 connector. **Matrix
+sends its token as a bearer header**, never the deprecated `?access_token=`
+query parameter that would land in the homeserver's request logs.
+
+Chat channels strip the markup characters a registrant could use to forge
+formatting or embed a link in your Slack channel. The `webhook` channel
+deliberately does not: its consumer is a machine, and a domain name is the
+primary key it correlates on.
+
+See **[Alerting](docs/guides/ALERTING.md)** for the full guide.
 
 **[⬆ Back to Top](#-table-of-contents)**
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -210,3 +210,42 @@ onepassword_item: ''
 enable_ml_ranking: false
 ml_min_labels: 30                  # Refuse to train below this many labels
 ml_explain_top: 3                  # Feature contributions recorded per finding
+
+# ---------------------------------------------------------------------------
+# Microsoft Teams
+# ---------------------------------------------------------------------------
+# Use a Power Automate "When a Teams webhook request is received" trigger and
+# paste its URL here. The older Office 365 connector (outlook.office.com) has
+# been retired by Microsoft and is no longer supported.
+# Prefer TYPO_SNIPER_TEAMS_WEBHOOK_URL or a secrets backend over this file.
+teams_webhook_url: ''
+
+# ---------------------------------------------------------------------------
+# Matrix
+# ---------------------------------------------------------------------------
+# Talks to the client-server API directly; no SDK needed. The access token is
+# sent as a bearer header, never as a query parameter, so it does not land in
+# the homeserver's request logs.
+matrix_homeserver: ''              # https://matrix.example.org
+matrix_access_token: ''            # Prefer TYPO_SNIPER_MATRIX_ACCESS_TOKEN
+matrix_room_id: ''                 # !roomid:example.org
+
+# ---------------------------------------------------------------------------
+# Jira — ticketing, not alerting
+# ---------------------------------------------------------------------------
+# Opens one issue per domain rather than one per scan, deduplicated by a
+# deterministic label, so a scheduled scan does not file the same lookalike
+# every morning. Only new, escalated, and activated findings are ticketed; a
+# resolved domain is good news, not work.
+#
+# Creation is capped per run. The first scan of a well-known brand can surface
+# hundreds of registered lookalikes, and turning that into hundreds of tickets
+# would be the most destructive thing this tool could do to your backlog.
+# Anything over the cap is logged and stays in the report and the delta JSON.
+jira_url: ''                       # https://you.atlassian.net
+jira_email: ''
+jira_api_token: ''                 # Prefer TYPO_SNIPER_JIRA_API_TOKEN
+jira_project_key: ''               # e.g. SEC
+jira_issue_type: Task
+jira_max_issues_per_run: 10
+jira_labels: []                    # Extra labels added to every issue

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Comprehensive documentation for Typo Sniper.
 - **[SECRETS_MANAGEMENT.md](guides/SECRETS_MANAGEMENT.md)** - Doppler, AWS, Vault, Azure, GCP, 1Password
 - **[AI_ANALYSIS.md](guides/AI_ANALYSIS.md)** - AI-assisted triage with Claude, OpenAI, Gemini, or Ollama
 - **[ML_TRIAGE.md](guides/ML_TRIAGE.md)** - Learned ranking from your own triage decisions
+- **[ALERTING.md](guides/ALERTING.md)** - Slack, Discord, Teams, Matrix, Jira, webhook, email
 - **[DEBUG_MODE.md](guides/DEBUG_MODE.md)** - Debug mode usage
 - **[DEBUG_IMPLEMENTATION.md](guides/DEBUG_IMPLEMENTATION.md)** - Debug system architecture
 - **[PERFORMANCE_OPTIMIZATION.md](guides/PERFORMANCE_OPTIMIZATION.md)** - Performance tuning
@@ -35,7 +36,8 @@ docs/
     ├── QUICKSTART.md                   # Quick start guide
     ├── SECRETS_MANAGEMENT.md           # Secrets management
     ├── AI_ANALYSIS.md                  # AI-assisted triage
-    └── ML_TRIAGE.md                    # Learned triage ranking
+    ├── ML_TRIAGE.md                    # Learned triage ranking
+    └── ALERTING.md                     # Alerting, notifications, ticketing
 ```
 
 ## Documentation by Topic

--- a/docs/config.yaml.example
+++ b/docs/config.yaml.example
@@ -210,3 +210,42 @@ onepassword_item: ''
 enable_ml_ranking: false
 ml_min_labels: 30                  # Refuse to train below this many labels
 ml_explain_top: 3                  # Feature contributions recorded per finding
+
+# ---------------------------------------------------------------------------
+# Microsoft Teams
+# ---------------------------------------------------------------------------
+# Use a Power Automate "When a Teams webhook request is received" trigger and
+# paste its URL here. The older Office 365 connector (outlook.office.com) has
+# been retired by Microsoft and is no longer supported.
+# Prefer TYPO_SNIPER_TEAMS_WEBHOOK_URL or a secrets backend over this file.
+teams_webhook_url: ''
+
+# ---------------------------------------------------------------------------
+# Matrix
+# ---------------------------------------------------------------------------
+# Talks to the client-server API directly; no SDK needed. The access token is
+# sent as a bearer header, never as a query parameter, so it does not land in
+# the homeserver's request logs.
+matrix_homeserver: ''              # https://matrix.example.org
+matrix_access_token: ''            # Prefer TYPO_SNIPER_MATRIX_ACCESS_TOKEN
+matrix_room_id: ''                 # !roomid:example.org
+
+# ---------------------------------------------------------------------------
+# Jira — ticketing, not alerting
+# ---------------------------------------------------------------------------
+# Opens one issue per domain rather than one per scan, deduplicated by a
+# deterministic label, so a scheduled scan does not file the same lookalike
+# every morning. Only new, escalated, and activated findings are ticketed; a
+# resolved domain is good news, not work.
+#
+# Creation is capped per run. The first scan of a well-known brand can surface
+# hundreds of registered lookalikes, and turning that into hundreds of tickets
+# would be the most destructive thing this tool could do to your backlog.
+# Anything over the cap is logged and stays in the report and the delta JSON.
+jira_url: ''                       # https://you.atlassian.net
+jira_email: ''
+jira_api_token: ''                 # Prefer TYPO_SNIPER_JIRA_API_TOKEN
+jira_project_key: ''               # e.g. SEC
+jira_issue_type: Task
+jira_max_issues_per_run: 10
+jira_labels: []                    # Extra labels added to every issue

--- a/docs/guides/ALERTING.md
+++ b/docs/guides/ALERTING.md
@@ -1,0 +1,140 @@
+# Alerting, Notifications, and Ticketing
+
+Typo Sniper alerts on **changes**, never on the full result set. A daily scan
+that re-reported the same seventy registered lookalikes every morning would be
+ignored within a week; one that says "a new lookalike appeared three days ago
+and it has MX records" gets read.
+
+## Channels
+
+| Channel | What it does | Needs |
+|---|---|---|
+| `slack` | Block Kit message to an incoming webhook | webhook URL |
+| `discord` | Embed to a webhook, coloured by severity | webhook URL |
+| `teams` | Adaptive Card via Power Automate | workflow URL |
+| `matrix` | Room message via the client-server API | homeserver, token, room |
+| `jira` | **One ticket per domain**, deduplicated | site, email, token, project |
+| `webhook` | Raw JSON to any endpoint | URL, optional auth header |
+| `email` | SMTP, HTML and plain text | SMTP settings |
+
+```bash
+python src/typo_sniper.py -i domains.txt --notify slack jira
+```
+
+Every credential resolves through the secrets backends, so none of them need
+to live in `config.yaml`. See [SECRETS_MANAGEMENT.md](SECRETS_MANAGEMENT.md).
+
+## Gating
+
+Three settings decide whether anything is sent at all:
+
+```yaml
+notify_min_changes: 1        # Suppress alerts below this many changes
+notify_on_no_changes: false  # Send a "nothing changed" message anyway
+notify_timeout: 20
+```
+
+## Alerting versus ticketing
+
+Slack, Discord, Teams, Matrix, email, and webhook are **alerting**: a message
+is disposable, and sending the same one twice is noise.
+
+Jira is **ticketing**, and a ticket is state. That difference drives its
+design.
+
+### Microsoft Teams
+
+Use a Power Automate **"When a Teams webhook request is received"** trigger and
+paste its URL into `teams_webhook_url`. Typo Sniper sends an Adaptive Card in
+the message envelope that trigger expects.
+
+The older Office 365 connector — the one with an `outlook.office.com` URL that
+took a `MessageCard` — has been **retired by Microsoft**. If you have an old
+connector URL lying around, it will not work; create a workflow instead.
+
+### Matrix
+
+```yaml
+matrix_homeserver: https://matrix.example.org
+matrix_room_id: '!yourroomid:example.org'
+```
+
+```bash
+export TYPO_SNIPER_MATRIX_ACCESS_TOKEN="syt_..."
+```
+
+No SDK is required — this talks to the client-server API directly. Two details
+worth knowing:
+
+- **The access token is sent as a bearer header**, not as the deprecated
+  `?access_token=` query parameter, which would put the credential in the
+  homeserver's request logs and in every proxy along the way.
+- **Each send carries a fresh transaction ID**, so a retried delivery is
+  idempotent at the homeserver rather than double-posting.
+
+Messages are sent as both plain text and HTML. The HTML half is escaped on top
+of the markup-stripping every channel already does, because that half is
+rendered as markup.
+
+### Jira
+
+```yaml
+jira_url: https://you.atlassian.net
+jira_email: security@you.example
+jira_project_key: SEC
+jira_issue_type: Task
+jira_max_issues_per_run: 10
+jira_labels: [typosquatting]
+```
+
+```bash
+export TYPO_SNIPER_JIRA_API_TOKEN="..."
+```
+
+Three rules make this safe to run on a schedule:
+
+**One issue per domain, not per scan.** A lookalike is tracked from detection
+through takedown, which is the unit of work an analyst actually has.
+
+**Deduplicated by a deterministic label.** Before creating anything, the
+project is searched for an open issue carrying `typosniper-<hash of domain>`.
+A scheduled scan therefore does not file the same lookalike every morning.
+An issue that was *closed* stays closed — if that domain later comes back, a
+new ticket is raised, which is correct, because it genuinely is a new event.
+
+**Creation is capped per run** (`jira_max_issues_per_run`, default 10). The
+first scan of a well-known brand can surface hundreds of registered lookalikes,
+and turning that into hundreds of tickets would be the most destructive thing
+this tool could do to someone's backlog. When the cap bites, the run logs how
+many were not filed, and those findings remain in the scan report and in
+`latest_changes.json`. The cap keeps the highest-risk findings.
+
+Only `new`, `escalated`, and `activated` changes are ticketed. A `resolved`
+domain is good news, not work, and a `changed` one is usually a detail on
+something already tracked.
+
+Credentials go out as a Basic `Authorization` header built with the standard
+library — never in the URL, where they would land in access logs.
+
+## Untrusted content
+
+Every payload carries third-party data: domain names, registrant fields, page
+titles, all written by the people being investigated.
+
+The chat channels **plain-text** their content, stripping control characters
+and the markup characters (`` ` ``, `*`, `_`, `~`, `|`, `<`, `>`, `[`, `]`)
+that would otherwise let a registrant forge formatting or embed a link in your
+Slack channel.
+
+The `webhook` channel deliberately does **not**. Its consumer is a machine — a
+SIEM, a script, a ticketing system — and a domain name is the primary key it
+correlates on, so mangling `g00gle<script>.com` into something prettier would
+corrupt the very field that matters. JSON encoding already prevents the payload
+from breaking out of its structure. Treat the values as untrusted at the point
+you render them.
+
+## Failure behaviour
+
+A channel that fails is logged and the others still fire. Delivery results are
+returned per channel, so a failing Slack webhook never costs you the Jira
+ticket. No alerting failure affects the scan, the report, or the exports.

--- a/src/config.py
+++ b/src/config.py
@@ -69,7 +69,8 @@ class Config:
 
     # Notifications (fire on changes only, never on the full result set)
     enable_notifications: bool = False
-    notify_channels: list = field(default_factory=list)  # slack, discord, webhook, email
+    # slack, discord, teams, matrix, jira, webhook, email
+    notify_channels: list = field(default_factory=list)
     notify_timeout: int = 20
     notify_min_changes: int = 1   # Suppress alerts below this many changes
     notify_on_no_changes: bool = False
@@ -78,6 +79,26 @@ class Config:
     discord_webhook_url: str | None = None
     webhook_url: str | None = None
     webhook_auth_header: str | None = None   # e.g. "Authorization: Bearer xyz"
+
+    # Microsoft Teams. Use a Power Automate "When a Teams webhook request is
+    # received" trigger; the older Office 365 connector has been retired.
+    teams_webhook_url: str | None = None
+
+    # Matrix, via the client-server API. No SDK required.
+    matrix_homeserver: str | None = None      # https://matrix.example.org
+    matrix_access_token: str | None = None
+    matrix_room_id: str | None = None         # !room:example.org
+
+    # Jira. This is ticketing rather than alerting: one issue per domain,
+    # deduplicated by a deterministic label, and capped per run so a first
+    # scan of a large brand cannot bury a backlog.
+    jira_url: str | None = None               # https://you.atlassian.net
+    jira_email: str | None = None
+    jira_api_token: str | None = None
+    jira_project_key: str | None = None       # e.g. SEC
+    jira_issue_type: str = 'Task'
+    jira_max_issues_per_run: int = 10
+    jira_labels: list = field(default_factory=list)
 
     smtp_host: str | None = None
     smtp_port: int = 587
@@ -235,6 +256,14 @@ class Config:
         ('discord_webhook_url', ('DISCORD_WEBHOOK_URL',)),
         ('webhook_url', ()),
         ('webhook_auth_header', ()),
+        ('teams_webhook_url', ('TEAMS_WEBHOOK_URL',)),
+        ('matrix_homeserver', ('MATRIX_HOMESERVER',)),
+        ('matrix_access_token', ('MATRIX_ACCESS_TOKEN',)),
+        ('matrix_room_id', ('MATRIX_ROOM_ID',)),
+        ('jira_url', ('JIRA_URL',)),
+        ('jira_email', ('JIRA_EMAIL',)),
+        ('jira_api_token', ('JIRA_API_TOKEN',)),
+        ('jira_project_key', ('JIRA_PROJECT_KEY',)),
         ('smtp_host', ()),
         ('smtp_username', ()),
         ('smtp_password', ()),

--- a/src/notifiers.py
+++ b/src/notifiers.py
@@ -15,13 +15,17 @@ the exporters do.
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
+import base64
+import hashlib
 import json
 import logging
 import smtplib
+import uuid
 from abc import ABC, abstractmethod
 from email.message import EmailMessage
 from html import escape
 from typing import Any
+from urllib.parse import quote
 
 import aiohttp
 
@@ -111,20 +115,53 @@ class BaseNotifier(ABC):
         self, url: str, payload: dict, session: aiohttp.ClientSession
     ) -> bool:
         """POST a JSON body, treating any 2xx as success."""
+        response = await self._request_json('POST', url, session, json=payload)
+        return response is not None
+
+    async def _request_json(
+        self,
+        method: str,
+        url: str,
+        session: aiohttp.ClientSession,
+        *,
+        json: dict | None = None,
+        headers: dict | None = None,
+    ) -> dict | None:
+        """
+        Send a request and decode a JSON response.
+
+        Args:
+            method: HTTP method
+            url: Absolute URL
+            session: Shared aiohttp session
+            json: Body to send
+            headers: Extra headers
+
+        Returns:
+            The decoded response body on any 2xx (an empty dict when the
+            response carries no JSON), or None on failure
+        """
         try:
             timeout = aiohttp.ClientTimeout(total=self.config.notify_timeout)
-            async with session.post(url, json=payload, timeout=timeout) as response:
+            async with session.request(
+                method, url, json=json, headers=headers, timeout=timeout,
+            ) as response:
                 if 200 <= response.status < 300:
                     self.logger.info(f"{self.name} alert delivered")
-                    return True
+                    try:
+                        return await response.json(content_type=None) or {}
+                    except (ValueError, aiohttp.ClientError):
+                        return {}
                 body = (await response.text())[:200]
                 self.logger.error(
                     f"{self.name} alert failed: HTTP {response.status} {body}"
                 )
-                return False
+                return None
         except Exception as e:
-            self.logger.error(f"{self.name} alert failed: {e}")
-            return False
+            # The message may quote the request; it never carries a token,
+            # which is sent as a header and not interpolated into the URL.
+            self.logger.error(f"{self.name} alert failed: {type(e).__name__}: {e}")
+            return None
 
 
 class SlackNotifier(BaseNotifier):
@@ -202,6 +239,302 @@ class DiscordNotifier(BaseNotifier):
         }
 
         return await self._post_json(url, {'embeds': [embed]}, session)
+
+
+class TeamsNotifier(BaseNotifier):
+    """
+    Post delta alerts to Microsoft Teams.
+
+    Sends an Adaptive Card wrapped in the message envelope a Power Automate
+    "When a Teams webhook request is received" trigger expects. That is the
+    current path: the older Office 365 connector, which took a MessageCard at
+    an ``outlook.office.com`` URL, has been retired by Microsoft.
+    """
+
+    name = 'Teams'
+
+    async def send(self, summary, session) -> bool:
+        url = self.config.teams_webhook_url
+        if not url:
+            return False
+
+        headline = build_headline(summary)
+        lines = build_lines(summary)
+
+        body = [
+            {
+                'type': 'TextBlock',
+                'size': 'Large',
+                'weight': 'Bolder',
+                'text': f'🎯 Typo Sniper: {headline}',
+                'wrap': True,
+            }
+        ]
+
+        if lines:
+            body.append({
+                'type': 'TextBlock',
+                # Adaptive Cards render a subset of markdown, and build_lines
+                # has already stripped the characters that could forge it.
+                'text': '\n\n'.join(lines)[:8000],
+                'wrap': True,
+            })
+
+        body.append({
+            'type': 'TextBlock',
+            'size': 'Small',
+            'isSubtle': True,
+            'text': f"{summary.get('total_changes', 0)} change(s) across monitored domains",
+            'wrap': True,
+        })
+
+        payload = {
+            'type': 'message',
+            'attachments': [{
+                'contentType': 'application/vnd.microsoft.card.adaptive',
+                'content': {
+                    'type': 'AdaptiveCard',
+                    '$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
+                    'version': '1.4',
+                    'body': body,
+                },
+            }],
+        }
+
+        return await self._post_json(url, payload, session)
+
+
+class MatrixNotifier(BaseNotifier):
+    """
+    Post delta alerts to a Matrix room.
+
+    Talks to the client-server API directly, so no SDK is required. The access
+    token is sent as a bearer header rather than the deprecated ``access_token``
+    query parameter, which would put the credential in the homeserver's request
+    logs and in any proxy along the way.
+    """
+
+    name = 'Matrix'
+
+    async def send(self, summary, session) -> bool:
+        homeserver = (self.config.matrix_homeserver or '').rstrip('/')
+        token = self.config.matrix_access_token
+        room = self.config.matrix_room_id
+
+        if not (homeserver and token and room):
+            return False
+
+        headline = build_headline(summary)
+        lines = build_lines(summary)
+
+        plain = f'🎯 Typo Sniper: {headline}'
+        if lines:
+            plain += '\n' + '\n'.join(lines)
+
+        # escape() on values that _plain has already stripped of angle brackets:
+        # belt and braces, because this half of the payload is rendered as HTML.
+        formatted = f'<b>🎯 Typo Sniper: {escape(headline)}</b>'
+        if lines:
+            items = ''.join(f'<li>{escape(line)}</li>' for line in lines)
+            formatted += f'<ul>{items}</ul>'
+
+        # A transaction ID makes a retried send idempotent at the homeserver
+        transaction_id = f'typosniper-{uuid.uuid4().hex}'
+        url = (
+            f'{homeserver}/_matrix/client/v3/rooms/'
+            f'{quote(room, safe="")}/send/m.room.message/{transaction_id}'
+        )
+
+        payload = {
+            'msgtype': 'm.text',
+            'body': plain[:16000],
+            'format': 'org.matrix.custom.html',
+            'formatted_body': formatted[:16000],
+        }
+
+        response = await self._request_json(
+            'PUT', url, session,
+            json=payload, headers={'Authorization': f'Bearer {token}'},
+        )
+        return response is not None
+
+
+class JiraNotifier(BaseNotifier):
+    """
+    Open a Jira issue per newly-noteworthy domain.
+
+    This is ticketing, not alerting, and the difference drives the design. A
+    chat message is disposable: sending the same one twice is noise. A ticket
+    is state, and a scheduled scan that opened a fresh ticket for the same
+    lookalike every morning would bury the queue within a week.
+
+    So two rules apply:
+
+      * **One issue per domain, not per scan.** A lookalike is tracked from
+        detection through takedown, which is the unit of work an analyst
+        actually has.
+      * **Deduplicated by a deterministic label.** Before creating anything,
+        the project is searched for an existing issue carrying this domain's
+        label. An issue that was closed stays closed — a domain that comes back
+        raises a new ticket, which is the correct outcome, since it genuinely
+        is a new event.
+
+    Creation is also capped per run. The first scan of a well-known brand can
+    surface hundreds of registered lookalikes, and turning that into hundreds
+    of tickets would be the single most destructive thing this tool could do to
+    someone's backlog.
+    """
+
+    name = 'Jira'
+
+    # Only these change kinds warrant a ticket. A resolved domain is good news
+    # and a changed one is usually a detail on something already tracked.
+    TICKETABLE = (NEW, ESCALATED, ACTIVATED)
+
+    def _auth_headers(self) -> dict[str, str] | None:
+        """
+        Basic credentials for the Jira REST API.
+
+        Encoded here rather than with aiohttp.BasicAuth, which is deprecated
+        and removed in aiohttp 4.0. base64 is standard library, so this works
+        on every version and adds no dependency.
+        """
+        email = self.config.jira_email
+        token = self.config.jira_api_token
+        if not (email and token):
+            return None
+        encoded = base64.b64encode(f'{email}:{token}'.encode()).decode()
+        return {'Authorization': f'Basic {encoded}'}
+
+    @staticmethod
+    def label_for(domain: str) -> str:
+        """
+        A deterministic, Jira-safe label identifying one domain.
+
+        Jira labels may not contain spaces, and a domain can be long or carry
+        characters Jira rejects, so the label is a hash. It is stable across
+        runs, which is what makes deduplication work.
+        """
+        digest = hashlib.sha256(str(domain or '').lower().encode()).hexdigest()[:16]
+        return f'typosniper-{digest}'
+
+    async def _existing_issue(self, label: str, session) -> str | None:
+        """Return the key of an open issue carrying this label, if any."""
+        jql = (
+            f'project = "{self.config.jira_project_key}" '
+            f'AND labels = "{label}" AND statusCategory != Done'
+        )
+        url = f'{self.config.jira_url.rstrip("/")}/rest/api/3/search/jql'
+        response = await self._request_json(
+            'POST', url, session,
+            json={'jql': jql, 'maxResults': 1, 'fields': ['key']},
+            headers=self._auth_headers(),
+        )
+        if not response:
+            return None
+        issues = response.get('issues') or []
+        return issues[0].get('key') if issues else None
+
+    def _description(self, change: dict[str, Any]) -> dict[str, Any]:
+        """Build an Atlassian Document Format description for one change."""
+        _, label, _ = KIND_STYLE.get(change['kind'], ('•', change['kind'], '#666'))
+        score = change.get('risk_score')
+
+        rows = [
+            f"Domain: {_plain(change.get('domain'), 120)}",
+            f"Monitored brand: {_plain(change.get('monitored_domain'), 120)}",
+            f"Change: {label}",
+            f"Risk score: {score if isinstance(score, (int, float)) else 'n/a'}",
+            f"Detail: {_plain(change.get('detail'), 300)}",
+        ]
+
+        return {
+            'type': 'doc',
+            'version': 1,
+            'content': [
+                {
+                    'type': 'paragraph',
+                    'content': [{'type': 'text', 'text': row}],
+                }
+                for row in rows
+            ] + [{
+                'type': 'paragraph',
+                'content': [{
+                    'type': 'text',
+                    'text': (
+                        'Risk score is computed deterministically from DNS, '
+                        'registration age, mail posture, TLS and HTTP evidence. '
+                        'Opened automatically by Typo Sniper.'
+                    ),
+                }],
+            }],
+        }
+
+    async def send(self, summary, session) -> bool:
+        if not (self.config.jira_url and self.config.jira_project_key
+                and self._auth_headers()):
+            return False
+
+        candidates = [
+            change for change in summary.get('changes', [])
+            if change.get('kind') in self.TICKETABLE and change.get('domain')
+        ]
+        if not candidates:
+            self.logger.debug('No ticketable changes in this scan')
+            return False
+
+        # Highest risk first, so the cap keeps what matters most
+        candidates.sort(key=lambda c: c.get('risk_score') or 0, reverse=True)
+
+        cap = max(0, int(self.config.jira_max_issues_per_run))
+        selected, skipped = candidates[:cap], candidates[cap:]
+
+        created, existing, failed = [], 0, 0
+        base = self.config.jira_url.rstrip('/')
+
+        for change in selected:
+            domain = change['domain']
+            label = self.label_for(domain)
+
+            if await self._existing_issue(label, session):
+                existing += 1
+                continue
+
+            payload = {
+                'fields': {
+                    'project': {'key': self.config.jira_project_key},
+                    'issuetype': {'name': self.config.jira_issue_type},
+                    'summary': (
+                        f'Typosquat: {_plain(domain, 100)} '
+                        f'({_plain(change.get("monitored_domain"), 60)})'
+                    )[:255],
+                    'description': self._description(change),
+                    'labels': [label, *self.config.jira_labels],
+                }
+            }
+
+            response = await self._request_json(
+                'POST', f'{base}/rest/api/3/issue', session,
+                json=payload, headers=self._auth_headers(),
+            )
+            if response and response.get('key'):
+                created.append(response['key'])
+            else:
+                failed += 1
+
+        if skipped:
+            # Never silent: a capped run must say what it did not file
+            self.logger.warning(
+                f'{len(skipped)} ticketable change(s) exceeded '
+                f'jira_max_issues_per_run={cap} and were not filed. '
+                f'They remain in the scan report and the delta JSON.'
+            )
+        self.logger.info(
+            f'Jira: {len(created)} issue(s) created, {existing} already tracked, '
+            f'{failed} failed'
+        )
+
+        return bool(created) or (existing > 0 and failed == 0)
 
 
 class WebhookNotifier(BaseNotifier):
@@ -339,6 +672,9 @@ class EmailNotifier(BaseNotifier):
 NOTIFIERS = {
     'slack': SlackNotifier,
     'discord': DiscordNotifier,
+    'teams': TeamsNotifier,
+    'matrix': MatrixNotifier,
+    'jira': JiraNotifier,
     'webhook': WebhookNotifier,
     'email': EmailNotifier,
 }

--- a/src/typo_sniper.py
+++ b/src/typo_sniper.py
@@ -620,9 +620,11 @@ Examples:
     parser.add_argument(
         '--notify',
         nargs='+',
-        choices=['slack', 'discord', 'webhook', 'email'],
+        choices=['slack', 'discord', 'teams', 'matrix', 'jira', 'webhook', 'email'],
         default=None,
-        help='Alert channels to notify when changes are detected'
+        help='Alert channels to notify when changes are detected. '
+             "'jira' opens one deduplicated ticket per domain rather than "
+             'sending a message.'
     )
 
     parser.add_argument(

--- a/src/version.py
+++ b/src/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -7,7 +7,10 @@ import pytest
 from notifiers import (
     DiscordNotifier,
     EmailNotifier,
+    JiraNotifier,
+    MatrixNotifier,
     SlackNotifier,
+    TeamsNotifier,
     WebhookNotifier,
     _plain,
     build_headline,
@@ -40,14 +43,24 @@ HOSTILE_CHANGE = {
 }
 
 
-def make_session(status=200, body=''):
+def make_session(status=200, body='', json_body=None):
+    """
+    A stub aiohttp session.
+
+    Every notifier goes through session.request, including the ones that only
+    ever POST, so that one mock covers Slack's POST and Matrix's PUT alike.
+    """
     response = MagicMock()
     response.status = status
     response.text = AsyncMock(return_value=body)
+    response.json = AsyncMock(return_value=json_body if json_body is not None else {})
     ctx = MagicMock()
     ctx.__aenter__ = AsyncMock(return_value=response)
     ctx.__aexit__ = AsyncMock(return_value=False)
     session = MagicMock()
+    session.request = MagicMock(return_value=ctx)
+    # WebhookNotifier bypasses the shared helper so it can send headers
+    # verbatim, so the stub answers on both.
     session.post = MagicMock(return_value=ctx)
     return session
 
@@ -119,7 +132,7 @@ class TestSlackNotifier:
             session,
         ) is True
 
-        payload = session.post.call_args.kwargs['json']
+        payload = session.request.call_args.kwargs['json']
         assert 'blocks' in payload
         assert '<script>' not in str(payload)
 
@@ -142,7 +155,7 @@ class TestSlackNotifier:
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(side_effect=OSError('unreachable'))
         ctx.__aexit__ = AsyncMock(return_value=False)
-        session.post = MagicMock(return_value=ctx)
+        session.request = MagicMock(return_value=ctx)
         assert await SlackNotifier(config).send(summary(), session) is False
 
 
@@ -158,7 +171,7 @@ class TestDiscordNotifier:
             session,
         ) is True
 
-        embed = session.post.call_args.kwargs['json']['embeds'][0]
+        embed = session.request.call_args.kwargs['json']['embeds'][0]
         assert 'Typo Sniper' in embed['title']
         assert isinstance(embed['color'], int)
 
@@ -171,7 +184,7 @@ class TestDiscordNotifier:
                     counts={NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
             session,
         )
-        assert session.post.call_args.kwargs['json']['embeds'][0]['color'] == 0xD73A49
+        assert session.request.call_args.kwargs['json']['embeds'][0]['color'] == 0xD73A49
 
 
 class TestWebhookNotifier:
@@ -343,7 +356,7 @@ class TestSanitisationBoundary:
                                 CHANGED: 0, RESOLVED: 0}),
                 session,
             )
-            body = str(session.post.call_args.kwargs['json'])
+            body = str(session.request.call_args.kwargs['json'])
             assert '<script>' not in body
             assert '`' not in body
 
@@ -362,3 +375,284 @@ class TestSanitisationBoundary:
 
         payload = session.post.call_args.kwargs['json']
         assert payload['changes'][0]['domain'] == HOSTILE_CHANGE['domain']
+
+
+NEW_COUNTS = {NEW: 1, ESCALATED: 0, ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}
+
+
+class TestTeamsNotifier:
+    @pytest.mark.asyncio
+    async def test_sends_an_adaptive_card(self, config):
+        config.teams_webhook_url = 'https://prod-1.westus.logic.azure.test/workflows/x'
+        session = make_session()
+
+        assert await TeamsNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE], counts=NEW_COUNTS), session
+        ) is True
+
+        payload = session.request.call_args.kwargs['json']
+        assert payload['type'] == 'message'
+        attachment = payload['attachments'][0]
+        assert attachment['contentType'] == 'application/vnd.microsoft.card.adaptive'
+        assert attachment['content']['type'] == 'AdaptiveCard'
+
+    @pytest.mark.asyncio
+    async def test_markup_is_neutralised(self, config):
+        """Adaptive Cards render markdown, so raw markup must not survive."""
+        config.teams_webhook_url = 'https://prod-1.westus.logic.azure.test/workflows/x'
+        session = make_session()
+        await TeamsNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE], counts=NEW_COUNTS), session
+        )
+        body = str(session.request.call_args.kwargs['json'])
+        assert '<script>' not in body
+        assert '`' not in body
+
+    @pytest.mark.asyncio
+    async def test_without_url_does_nothing(self, config):
+        config.teams_webhook_url = None
+        assert await TeamsNotifier(config).send(summary(), make_session()) is False
+
+    @pytest.mark.asyncio
+    async def test_http_error_is_a_failure(self, config):
+        config.teams_webhook_url = 'https://prod-1.westus.logic.azure.test/workflows/x'
+        assert await TeamsNotifier(config).send(
+            summary(), make_session(status=400, body='bad card')
+        ) is False
+
+
+class TestMatrixNotifier:
+    def _configure(self, config):
+        config.matrix_homeserver = 'https://matrix.example.test/'
+        config.matrix_access_token = 'syt_secret_token'
+        config.matrix_room_id = '!abc:example.test'
+
+    @pytest.mark.asyncio
+    async def test_puts_to_the_room_send_endpoint(self, config):
+        self._configure(config)
+        session = make_session()
+
+        assert await MatrixNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE], counts=NEW_COUNTS), session
+        ) is True
+
+        method, url = session.request.call_args.args[:2]
+        assert method == 'PUT'
+        assert '/_matrix/client/v3/rooms/' in url
+        assert '/send/m.room.message/' in url
+
+    @pytest.mark.asyncio
+    async def test_room_id_is_url_encoded(self, config):
+        """A room ID starts with ! and contains :, both of which need escaping."""
+        self._configure(config)
+        session = make_session()
+        await MatrixNotifier(config).send(summary(), session)
+
+        url = session.request.call_args.args[1]
+        assert '%21abc%3Aexample.test' in url
+
+    @pytest.mark.asyncio
+    async def test_token_is_sent_as_a_header_not_in_the_url(self, config):
+        """A query-parameter token lands in homeserver and proxy logs."""
+        self._configure(config)
+        session = make_session()
+        await MatrixNotifier(config).send(summary(), session)
+
+        url = session.request.call_args.args[1]
+        headers = session.request.call_args.kwargs['headers']
+        assert 'syt_secret_token' not in url
+        assert headers['Authorization'] == 'Bearer syt_secret_token'
+
+    @pytest.mark.asyncio
+    async def test_each_send_uses_a_fresh_transaction_id(self, config):
+        self._configure(config)
+        session = make_session()
+        await MatrixNotifier(config).send(summary(), session)
+        first = session.request.call_args.args[1]
+        await MatrixNotifier(config).send(summary(), session)
+        second = session.request.call_args.args[1]
+        assert first != second
+
+    @pytest.mark.asyncio
+    async def test_html_body_escapes_untrusted_content(self, config):
+        self._configure(config)
+        session = make_session()
+        await MatrixNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE], counts=NEW_COUNTS), session
+        )
+        formatted = session.request.call_args.kwargs['json']['formatted_body']
+        assert '<script>' not in formatted
+
+    @pytest.mark.asyncio
+    async def test_incomplete_configuration_does_nothing(self, config):
+        self._configure(config)
+        config.matrix_access_token = None
+        assert await MatrixNotifier(config).send(summary(), make_session()) is False
+
+
+def ticketable(domain='evil.com', kind=NEW, score=80):
+    return {
+        'kind': kind, 'domain': domain, 'risk_score': score,
+        'detail': 'newly detected', 'monitored_domain': 'brand.com',
+    }
+
+
+class TestJiraNotifier:
+    def _configure(self, config):
+        config.jira_url = 'https://acme.atlassian.test'
+        config.jira_email = 'security@acme.test'
+        config.jira_api_token = 'token'
+        config.jira_project_key = 'SEC'
+
+    def _session(self, search_hits=0, created_key='SEC-1'):
+        """A session answering a JQL search then an issue creation."""
+        search = MagicMock()
+        search.status = 200
+        search.text = AsyncMock(return_value='')
+        search.json = AsyncMock(return_value={
+            'issues': [{'key': 'SEC-9'}] * search_hits
+        })
+        create = MagicMock()
+        create.status = 201
+        create.text = AsyncMock(return_value='')
+        create.json = AsyncMock(return_value={'key': created_key})
+
+        def responder(method, url, **kwargs):
+            ctx = MagicMock()
+            target = search if url.endswith('/search/jql') else create
+            ctx.__aenter__ = AsyncMock(return_value=target)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        session = MagicMock()
+        session.request = MagicMock(side_effect=responder)
+        return session
+
+    def _creates(self, session):
+        return [c for c in session.request.call_args_list
+                if c.args[1].endswith('/rest/api/3/issue')]
+
+    @pytest.mark.asyncio
+    async def test_creates_an_issue_for_a_new_domain(self, config):
+        self._configure(config)
+        session = self._session()
+
+        assert await JiraNotifier(config).send(
+            summary(changes=[ticketable()], counts=NEW_COUNTS), session
+        ) is True
+
+        creates = self._creates(session)
+        assert len(creates) == 1
+        fields = creates[0].kwargs['json']['fields']
+        assert fields['project'] == {'key': 'SEC'}
+        assert 'evil.com' in fields['summary']
+        assert fields['description']['type'] == 'doc'
+
+    @pytest.mark.asyncio
+    async def test_an_already_tracked_domain_is_not_filed_twice(self, config):
+        """A scheduled scan must not open a fresh ticket every morning."""
+        self._configure(config)
+        session = self._session(search_hits=1)
+
+        await JiraNotifier(config).send(
+            summary(changes=[ticketable()], counts=NEW_COUNTS), session
+        )
+        assert self._creates(session) == []
+
+    @pytest.mark.asyncio
+    async def test_the_dedupe_label_is_stable_for_a_domain(self, config):
+        assert JiraNotifier.label_for('evil.com') == JiraNotifier.label_for('EVIL.com')
+        assert JiraNotifier.label_for('a.com') != JiraNotifier.label_for('b.com')
+        assert ' ' not in JiraNotifier.label_for('evil.com')
+
+    @pytest.mark.asyncio
+    async def test_creation_is_capped_per_run(self, config):
+        """A first scan of a large brand must not bury a backlog."""
+        self._configure(config)
+        config.jira_max_issues_per_run = 3
+        session = self._session()
+
+        changes = [ticketable(f'evil{i}.com', score=i) for i in range(20)]
+        await JiraNotifier(config).send(
+            summary(changes=changes, counts={NEW: 20, ESCALATED: 0,
+                                             ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            session,
+        )
+        assert len(self._creates(session)) == 3
+
+    @pytest.mark.asyncio
+    async def test_the_cap_keeps_the_highest_risk(self, config):
+        self._configure(config)
+        config.jira_max_issues_per_run = 2
+        session = self._session()
+
+        changes = [ticketable('low.com', score=10), ticketable('high.com', score=95),
+                   ticketable('mid.com', score=50)]
+        await JiraNotifier(config).send(
+            summary(changes=changes, counts={NEW: 3, ESCALATED: 0,
+                                             ACTIVATED: 0, CHANGED: 0, RESOLVED: 0}),
+            session,
+        )
+        filed = {c.kwargs['json']['fields']['summary'] for c in self._creates(session)}
+        assert any('high.com' in s for s in filed)
+        assert not any('low.com' in s for s in filed)
+
+    @pytest.mark.asyncio
+    async def test_a_capped_run_says_what_it_did_not_file(self, config, caplog):
+        self._configure(config)
+        config.jira_max_issues_per_run = 1
+        session = self._session()
+        await JiraNotifier(config).send(
+            summary(changes=[ticketable('a.com'), ticketable('b.com')],
+                    counts={NEW: 2, ESCALATED: 0, ACTIVATED: 0,
+                            CHANGED: 0, RESOLVED: 0}),
+            session,
+        )
+        assert 'were not filed' in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_resolved_changes_do_not_open_tickets(self, config):
+        """A domain going away is good news, not work."""
+        self._configure(config)
+        session = self._session()
+        await JiraNotifier(config).send(
+            summary(changes=[ticketable('gone.com', kind=RESOLVED)],
+                    counts={NEW: 0, ESCALATED: 0, ACTIVATED: 0,
+                            CHANGED: 0, RESOLVED: 1}),
+            session,
+        )
+        assert self._creates(session) == []
+
+    @pytest.mark.asyncio
+    async def test_incomplete_configuration_does_nothing(self, config):
+        self._configure(config)
+        config.jira_api_token = None
+        assert await JiraNotifier(config).send(
+            summary(changes=[ticketable()], counts=NEW_COUNTS), make_session()
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_untrusted_fields_are_neutralised_in_the_ticket(self, config):
+        self._configure(config)
+        session = self._session()
+        await JiraNotifier(config).send(
+            summary(changes=[HOSTILE_CHANGE], counts=NEW_COUNTS), session
+        )
+        body = str(self._creates(session)[0].kwargs['json'])
+        assert '<script>' not in body
+
+    @pytest.mark.asyncio
+    async def test_credentials_are_sent_as_a_basic_header(self, config):
+        """Not in the URL, where they would land in access logs."""
+        import base64
+
+        self._configure(config)
+        session = self._session()
+        await JiraNotifier(config).send(
+            summary(changes=[ticketable()], counts=NEW_COUNTS), session
+        )
+
+        call = self._creates(session)[0]
+        expected = base64.b64encode(b'security@acme.test:token').decode()
+        assert call.kwargs['headers']['Authorization'] == f'Basic {expected}'
+        assert 'token' not in call.args[1]


### PR DESCRIPTION
Closes the remaining channels from #9 — Teams, Matrix, and Jira — and adds ticketing as something distinct from alerting.

Fixes #9.

---

## Jira is ticketing, not alerting

This is the design decision worth your attention. Slack, Discord, Teams, Matrix, email, and webhook are **alerting**: a message is disposable, and sending the same one twice is noise. **A ticket is state.** A scheduled scan that opened a fresh ticket for the same lookalike every morning would bury a queue within a week.

So three rules apply:

- **One issue per domain, not per scan.** A lookalike is tracked from detection through takedown, which is the unit of work an analyst actually has.
- **Deduplicated by a deterministic label.** Before creating anything, the project is searched for an open issue carrying `typosniper-<hash of domain>`. A *closed* issue stays closed — if that domain comes back, a new ticket is raised, which is correct, because it genuinely is a new event.
- **Creation is capped per run** (`jira_max_issues_per_run`, default 10). The first scan of a well-known brand can surface hundreds of registered lookalikes, and turning that into hundreds of tickets would be the most destructive thing this tool could do to your backlog. What the cap drops is logged, stays in the report and the delta JSON, and the cap keeps the highest-risk findings.

Only `new`, `escalated`, and `activated` findings are ticketed. A `resolved` domain is good news, not work.

## Teams

An Adaptive Card sent to a Power Automate **"When a Teams webhook request is received"** trigger.

That is the current path — the older Office 365 connector, which took a `MessageCard` at an `outlook.office.com` URL, has been **retired by Microsoft**. An old connector URL will not work, and the guide says so rather than letting someone paste one in and wonder why nothing arrives.

## Matrix

The client-server API directly, no SDK. Two details that matter:

- **The access token is sent as a bearer header**, not the deprecated `?access_token=` query parameter — that would put the credential in the homeserver's request logs and in every proxy along the way. There's a test asserting the token never appears in the URL.
- **Each send carries a fresh transaction ID**, so a retried delivery is idempotent at the homeserver rather than double-posting.

The HTML half of the message is escaped on top of the markup-stripping every channel already does, because that half is rendered as markup.

## A deprecation caught before it broke

`aiohttp.BasicAuth` is deprecated and **removed in aiohttp 4.0**. The Jira Basic header is now built with the standard library — works on every aiohttp version, adds no dependency.

Found by running the notifier tests with `-W error::DeprecationWarning` rather than by waiting for aiohttp 4 to land and break the build.

## Refactor

Notifiers now share one request helper supporting any HTTP method and custom headers, so Slack's POST and Matrix's PUT get the same timeout, error handling, and logging. `WebhookNotifier` keeps its own call **deliberately** — it sends operator-supplied headers verbatim, and routing it through the shared helper would have quietly changed that contract.

Teams, Matrix, and Jira credentials resolve through the secrets backends (#28) like every other credential, so none of them need to sit in `config.yaml`.

## Verification

- **575 tests pass** (up from 555) on **both Python 3.10 and 3.11**, `ruff check src/ tests/` clean
- 20 new tests, including the ones that pin the design: an already-tracked domain is not filed twice, the cap keeps the highest-risk findings, a capped run logs what it did not file, resolved changes open no tickets, the Matrix token is not in the URL, room IDs are URL-encoded (`!` and `:` both need it), and hostile registrant text is neutralised in every channel
- Notifier tests re-run under `-W error::DeprecationWarning` to confirm the aiohttp fix
- CI's smoke step reproduced locally on 3.10 (`config.yaml.example` loads, `--version`, `--help`)

## Not verified in this environment

No live delivery to Teams, Matrix, or Jira was possible — outbound access to those endpoints is blocked by the sandbox proxy. Request shapes are asserted against stubs, not real services. First real use is worth doing against a test Jira project, since that is the channel that creates state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_