### PR TITLE
Add Terraform/OpenTofu modules for ECS Fargate and EKS (v2.2.0)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,9 +46,11 @@ coverage.xml
 htmlcov/
 requirements-dev.txt
 
-# Docker
+# Docker. The uploader is copied into the image by docker/Dockerfile, so it
+# has to survive this exclusion — see the pyproject.toml note above.
 .dockerignore
 docker/
+!docker/upload-results.py
 
 # Documentation and media. README.md is kept: pyproject.toml names it as the
 # package readme, so the build fails without it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-08-27
+
+### Added
+
+- **Terraform / OpenTofu modules** for running Typo Sniper as a scheduled
+  scanner on AWS, in `infra/terraform/`: a Fargate task driven by EventBridge
+  Scheduler, a Kubernetes CronJob for teams already on EKS, and a shared module
+  holding the S3 reports bucket, EFS state, Secrets Manager secret, and
+  security groups both use. Working examples for each.
+
+- **boto3 and a report uploader in the container image.** The image is how
+  people run this on AWS, and both the Secrets Manager backend and shipping
+  reports to S3 need a client. `typo-sniper-upload` sends a finished scan's
+  reports to `RESULTS_BUCKET`, and is inert when that variable is unset.
+
+- **`TYPO_SNIPER_STATE_DIR`, `TYPO_SNIPER_OUTPUT_DIR` and
+  `TYPO_SNIPER_CACHE_DIR`.** A container image ships a default and the
+  deployment redirects it, so for these three the environment wins — unlike
+  credentials, where an explicit config value is a deliberate act and takes
+  precedence.
+
+### Fixed
+
+- **A containerised deployment could silently stop detecting changes.** The
+  scan history that every delta is computed against lives in `state_dir`, which
+  had no environment override, so a container had no way to point it at a
+  persistent volume without a config file baked into the image. On ephemeral
+  storage every scheduled run looks like a first run: no deltas, no alerts, and
+  a scanner that appears to work perfectly while doing none of the job it was
+  deployed for. Nothing errors and nothing warns, which is what makes it worth
+  calling out.
+
+  Found while writing the IaC — the Terraform set the variable and the
+  application ignored it.
+
+- **The container image had no AWS client**, so on AWS the documented Secrets
+  Manager backend resolved nothing and the scan ran with no API keys at all,
+  reporting no error. Weighing the megabytes against a scanner that quietly
+  runs unauthenticated, the megabytes lose.
+
+- **`.dockerignore` excluded `docker/`**, which would have broken the image
+  build once the uploader was copied in — the same way it excluded
+  `pyproject.toml` in 2.0.0. Caught this time by building the context before
+  pushing rather than after CI failed.
+
 ## [2.1.0] - 2026-08-27
 
 The scanner can now see what a suspicious page is built to *do*, not just that

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,20 @@ COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 RUN pip install --no-cache-dir --no-deps .
 
+# boto3, for the AWS Secrets Manager backend and for shipping reports to S3.
+#
+# It is in the image rather than left to an extra because the container is how
+# people run this on AWS, and there the omission is silent: without boto3 the
+# documented AWS secrets backend resolves nothing and the scan runs with no API
+# keys at all, reporting no error. Weighing ~90MB against a scanner that
+# quietly runs unauthenticated, the megabytes lose.
+RUN pip install --no-cache-dir "boto3>=1.35.0"
+
+# Ships scan reports to S3 after a run. Used by the Terraform modules in
+# infra/; harmless and inert when RESULTS_BUCKET is unset.
+COPY docker/upload-results.py /usr/local/bin/typo-sniper-upload
+RUN chmod 0755 /usr/local/bin/typo-sniper-upload
+
 # Run as an unprivileged user. The scanner only needs outbound network access,
 # so there is no reason to give it root inside the container.
 RUN useradd --create-home --uid 10001 sniper \

--- a/docker/upload-results.py
+++ b/docker/upload-results.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Ship a completed scan's reports to S3.
+
+A separate script rather than an inline ``python -c`` in the task definition:
+that would be a Python string inside a shell string inside a JSON string inside
+HCL, and every layer of escaping there is somewhere a bug can hide silently.
+
+Reads RESULTS_BUCKET and RESULTS_PREFIX from the environment. Uploading is
+best-effort per file: one unreadable report should not discard the rest of a
+scan's output.
+"""
+
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 ChiefGyk3D
+# Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
+
+import os
+import pathlib
+import sys
+
+
+def main() -> int:
+    bucket = os.environ.get('RESULTS_BUCKET')
+    if not bucket:
+        print('RESULTS_BUCKET is not set; nothing to upload', file=sys.stderr)
+        return 0
+
+    prefix = os.environ.get('RESULTS_PREFIX', '').strip('/')
+    source = pathlib.Path(os.environ.get('RESULTS_DIR', '/app/results'))
+
+    if not source.is_dir():
+        print(f'{source} does not exist; nothing to upload', file=sys.stderr)
+        return 0
+
+    import boto3
+
+    client = boto3.client('s3')
+    uploaded = failed = 0
+
+    for path in sorted(source.rglob('*')):
+        if not path.is_file():
+            continue
+
+        relative = path.relative_to(source).as_posix()
+        key = f'{prefix}/{relative}' if prefix else relative
+
+        try:
+            client.upload_file(str(path), bucket, key)
+            uploaded += 1
+        except Exception as e:
+            # Only the exception type: a client error message can echo the
+            # request, and these run in a log an operator may ship elsewhere.
+            print(f'Failed to upload {relative} ({type(e).__name__})', file=sys.stderr)
+            failed += 1
+
+    print(f'Uploaded {uploaded} report file(s) to s3://{bucket}/{prefix}')
+
+    # A scan whose reports did not reach S3 has not really finished, so a
+    # complete failure is an error the scheduler should surface.
+    return 1 if failed and not uploaded else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Comprehensive documentation for Typo Sniper.
 - **[AI_ANALYSIS.md](guides/AI_ANALYSIS.md)** - AI-assisted triage with Claude, OpenAI, Gemini, or Ollama
 - **[ML_TRIAGE.md](guides/ML_TRIAGE.md)** - Learned ranking from your own triage decisions
 - **[ALERTING.md](guides/ALERTING.md)** - Slack, Discord, Teams, Matrix, Jira, webhook, email
+- **[infra/README.md](../infra/README.md)** - Terraform/OpenTofu for ECS Fargate and EKS
 - **[DEBUG_MODE.md](guides/DEBUG_MODE.md)** - Debug mode usage
 - **[DEBUG_IMPLEMENTATION.md](guides/DEBUG_IMPLEMENTATION.md)** - Debug system architecture
 - **[PERFORMANCE_OPTIMIZATION.md](guides/PERFORMANCE_OPTIMIZATION.md)** - Performance tuning

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,151 @@
+# Infrastructure as Code
+
+Terraform / OpenTofu modules for running Typo Sniper as a scheduled scanner on
+AWS. Two deployment shapes, sharing one set of supporting resources.
+
+```
+infra/terraform/
+├── modules/
+│   ├── common/        S3 reports bucket, EFS state, Secrets Manager, security groups
+│   ├── ecs-fargate/   Scheduled Fargate task via EventBridge Scheduler
+│   └── eks-cronjob/   Kubernetes CronJob on an existing EKS cluster
+└── examples/
+    ├── ecs-fargate/   Complete working deployment
+    └── eks-cronjob/   Complete working deployment
+```
+
+## Which one
+
+**ECS Fargate** unless you have a reason not to. Typo Sniper is a batch job: it
+wakes up, scans for a few minutes, writes a report, and exits. Fargate bills
+for those minutes and there is no cluster idling between runs.
+
+**EKS CronJob** if your scheduling, alerting, and on-call already run through
+Kubernetes. Same workload, same bucket, same secret — the difference is only
+what starts the container.
+
+**Not Lambda.** A scan of a well-known brand routinely runs longer than
+Lambda's 15-minute ceiling, and the failure mode is a truncated scan that looks
+like a clean one.
+
+## The thing that is easy to get wrong
+
+Typo Sniper detects **changes**. It compares each scan against the previous one
+and keeps that history in `state_dir`.
+
+A container starts with an empty filesystem. Put `state_dir` on ephemeral
+storage and every scheduled run looks like a first run: no deltas are computed,
+no alerts fire, and the scanner appears to work perfectly while doing none of
+the job it was deployed for. Nothing errors. Nothing warns.
+
+Both modules mount **EFS** at `state_dir` for exactly this reason, and the
+`common` module enables EFS backups — losing scan history means losing the
+baseline every alert is measured against, so the next run reports every known
+lookalike as new.
+
+If you deploy this some other way, that is the detail to get right.
+
+## Quick start
+
+```bash
+cd infra/terraform/examples/ecs-fargate
+
+cat > terraform.tfvars <<'VARS'
+vpc_id     = "vpc-0123456789abcdef0"
+subnet_ids = ["subnet-0a1b2c3d", "subnet-4e5f6a7b"]
+domains    = ["yourbrand.com", "yourbrand.co.uk"]
+VARS
+
+tofu init
+tofu apply
+```
+
+Then populate the secret it created. It is deliberately **not** managed by
+Terraform: putting credentials in a variable writes them to state in clear
+text, which is the thing a secrets backend exists to prevent.
+
+```bash
+aws secretsmanager put-secret-value \
+  --secret-id "$(tofu output -raw secret_name)" \
+  --secret-string '{
+    "urlscan_api_key": "...",
+    "slack_webhook_url": "https://hooks.slack.com/services/...",
+    "ai_api_key": "sk-ant-..."
+  }'
+```
+
+Key names are Typo Sniper's own — see
+[SECRETS_MANAGEMENT.md](../docs/guides/SECRETS_MANAGEMENT.md). The task reads
+them through the scanner's AWS backend, so nothing lands in the task
+definition, where it would be readable by anyone with
+`ecs:DescribeTaskDefinition`.
+
+Trigger a run without waiting for the schedule:
+
+```bash
+eval "$(tofu output -raw run_now)"
+```
+
+## What it creates
+
+| Resource | Why |
+|---|---|
+| S3 bucket | Scan reports. Versioned, encrypted, public access blocked, lifecycle-expired |
+| EFS file system + access point | Scan history between runs. Encrypted, backed up |
+| Secrets Manager secret | API keys and webhook URLs, populated out of band |
+| Security groups | Task egress only; NFS restricted to the task's own group |
+| IAM roles | Execution, task, and either scheduler or IRSA |
+| CloudWatch log group | Scan output, retained 30 days by default |
+| EventBridge schedule *or* CronJob | Whatever starts the scan |
+
+### Permissions
+
+The scan task can do three things and nothing else:
+
+- **`s3:PutObject`** to its own bucket. No `GetObject` and no `DeleteObject` —
+  a compromised scan task should not be able to read another run's findings.
+- **`secretsmanager:GetSecretValue`** on one named secret, not every secret in
+  the account.
+- **Mount one EFS access point**, conditioned on the access point ARN.
+
+The EventBridge scheduler role can start this one task definition on this one
+cluster, and pass only the two roles the task needs. Its trust policy is scoped
+with `aws:SourceAccount` to close the confused-deputy path. The EKS variant's
+IRSA trust policy is scoped to one service account in one namespace; without
+that condition any pod in the cluster could assume the role.
+
+## Requirements
+
+Both:
+- OpenTofu ≥ 1.5 or Terraform ≥ 1.5
+- AWS provider ≥ 6.0
+- An existing VPC with subnets that have outbound internet access. The
+  scanner's entire job is reaching DNS, RDAP, and suspicious hosts.
+
+EKS additionally:
+- An existing cluster with an IAM OIDC provider
+- The **EFS CSI driver installed** — this module does not install it, because
+  a CSI driver is a cluster-wide concern and a scan job has no business owning
+  one
+- The target namespace already created
+
+## Pin the image
+
+Both modules default to a version tag, not `:latest`. Keep it that way. A
+scheduled job silently picking up a new image is how a scan starts failing at
+3am with nothing in the change log to explain it.
+
+## Cost
+
+The scan itself is minutes of Fargate a day. In practice the standing cost is
+EFS (a few GB at most, with IA transition after 30 days) and S3. Container
+Insights is enabled on a cluster this module creates; turn it off if you do not
+want the CloudWatch charge.
+
+## Verification status
+
+These modules are **syntax-checked and canonically formatted**
+(`tofu fmt -check -recursive`, which parses the HCL and rejects malformed
+configuration) but have **not been schema-validated or planned** against real
+AWS. Run `tofu validate` and `tofu plan` in your own account before applying —
+that will catch any argument that a provider version rejects.

--- a/infra/terraform/examples/ecs-fargate/main.tf
+++ b/infra/terraform/examples/ecs-fargate/main.tf
@@ -1,0 +1,54 @@
+# A complete scheduled scanner on ECS Fargate.
+#
+#   tofu init && tofu apply
+#
+# Then put the real credentials into the secret this creates — see the module
+# README. Nothing is published or scanned until you do.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "common" {
+  source = "../../modules/common"
+
+  name       = var.name
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+module "scanner" {
+  source = "../../modules/ecs-fargate"
+
+  name       = var.name
+  subnet_ids = var.subnet_ids
+  common     = module.common
+
+  domains = var.domains
+
+  # Daily at 06:00 UTC. A scan of a large brand takes minutes.
+  schedule_expression = "cron(0 6 * * ? *)"
+
+  # Alerts fire on changes only, so a daily scan that finds nothing new is
+  # silent. See docs/guides/ALERTING.md.
+  extra_args = ["--notify", "slack"]
+
+  # Only needed when running in public subnets with no NAT gateway. The
+  # scanner cannot do its job without outbound access.
+  assign_public_ip = var.assign_public_ip
+}

--- a/infra/terraform/examples/ecs-fargate/outputs.tf
+++ b/infra/terraform/examples/ecs-fargate/outputs.tf
@@ -1,0 +1,25 @@
+output "results_bucket" {
+  description = "Where scan reports land."
+  value       = module.common.results_bucket
+}
+
+output "secret_name" {
+  description = "Populate this secret with your API keys and webhook URLs."
+  value       = module.common.secret_name
+}
+
+output "log_group" {
+  description = "CloudWatch log group holding scan output."
+  value       = module.scanner.log_group
+}
+
+output "run_now" {
+  description = "Command to trigger a scan immediately, without waiting for the schedule."
+  value = join(" ", [
+    "aws ecs run-task",
+    "--cluster ${module.scanner.cluster_arn}",
+    "--task-definition ${module.scanner.task_definition_arn}",
+    "--launch-type FARGATE",
+    "--network-configuration 'awsvpcConfiguration={subnets=[${join(",", var.subnet_ids)}],securityGroups=[${module.common.task_security_group_id}],assignPublicIp=${var.assign_public_ip ? "ENABLED" : "DISABLED"}}'",
+  ])
+}

--- a/infra/terraform/examples/ecs-fargate/variables.tf
+++ b/infra/terraform/examples/ecs-fargate/variables.tf
@@ -1,0 +1,39 @@
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Name prefix for created resources."
+  type        = string
+  default     = "typo-sniper"
+}
+
+variable "environment" {
+  description = "Environment tag."
+  type        = string
+  default     = "production"
+}
+
+variable "vpc_id" {
+  description = "Existing VPC for the EFS mount targets and the scan task."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets with outbound internet access."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Set true for public subnets without a NAT gateway."
+  type        = bool
+  default     = false
+}
+
+variable "domains" {
+  description = "Domains to monitor."
+  type        = list(string)
+  default     = ["example.com"]
+}

--- a/infra/terraform/examples/eks-cronjob/main.tf
+++ b/infra/terraform/examples/eks-cronjob/main.tf
@@ -1,0 +1,77 @@
+# A scheduled scanner as a CronJob on an existing EKS cluster.
+#
+# Assumes the cluster already exists and the EFS CSI driver is installed. This
+# module deliberately creates neither: a scan job has no business owning a
+# cluster, and the CSI driver is a cluster-wide concern.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.30"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_eks_cluster" "this" {
+  name = var.cluster_name
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = var.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+locals {
+  # The IRSA trust policy keys off the issuer URL without its scheme.
+  oidc_url = replace(data.aws_eks_cluster.this.identity[0].oidc[0].issuer, "https://", "")
+}
+
+data "aws_iam_openid_connect_provider" "cluster" {
+  url = data.aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
+
+module "common" {
+  source = "../../modules/common"
+
+  name       = var.name
+  vpc_id     = data.aws_eks_cluster.this.vpc_config[0].vpc_id
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Environment = var.environment
+  }
+}
+
+module "scanner" {
+  source = "../../modules/eks-cronjob"
+
+  name      = var.name
+  namespace = var.namespace
+  common    = module.common
+
+  oidc_provider_arn = data.aws_iam_openid_connect_provider.cluster.arn
+  oidc_provider_url = local.oidc_url
+
+  domains = var.domains
+
+  # Daily at 06:00, cluster time.
+  schedule = "0 6 * * *"
+
+  extra_args = ["--notify", "slack"]
+}

--- a/infra/terraform/examples/eks-cronjob/outputs.tf
+++ b/infra/terraform/examples/eks-cronjob/outputs.tf
@@ -1,0 +1,19 @@
+output "results_bucket" {
+  description = "Where scan reports land."
+  value       = module.common.results_bucket
+}
+
+output "secret_name" {
+  description = "Populate this secret with your API keys and webhook URLs."
+  value       = module.common.secret_name
+}
+
+output "cron_job" {
+  description = "The CronJob running the scan."
+  value       = module.scanner.cron_job_name
+}
+
+output "run_now" {
+  description = "Command to trigger a scan immediately."
+  value       = "kubectl -n ${var.namespace} create job --from=cronjob/${module.scanner.cron_job_name} ${var.name}-manual"
+}

--- a/infra/terraform/examples/eks-cronjob/variables.tf
+++ b/infra/terraform/examples/eks-cronjob/variables.tf
@@ -1,0 +1,42 @@
+variable "region" {
+  description = "AWS region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Name prefix for created resources."
+  type        = string
+  default     = "typo-sniper"
+}
+
+variable "environment" {
+  description = "Environment tag."
+  type        = string
+  default     = "production"
+}
+
+variable "cluster_name" {
+  description = "Existing EKS cluster to deploy into."
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace. Must already exist."
+  type        = string
+  default     = "security"
+}
+
+variable "subnet_ids" {
+  description = <<-EOT
+    Subnets for the EFS mount targets. Use the cluster's node subnets so the
+    pods can reach the file system.
+  EOT
+  type        = list(string)
+}
+
+variable "domains" {
+  description = "Domains to monitor."
+  type        = list(string)
+  default     = ["example.com"]
+}

--- a/infra/terraform/modules/common/main.tf
+++ b/infra/terraform/modules/common/main.tf
@@ -1,0 +1,213 @@
+# Pieces both deployment shapes need: somewhere to put reports, somewhere to
+# keep scan state across runs, and somewhere to keep credentials.
+
+locals {
+  tags = merge({
+    Application = "typo-sniper"
+    ManagedBy   = "terraform"
+  }, var.tags)
+}
+
+# --- Reports -----------------------------------------------------------------
+
+resource "aws_s3_bucket" "results" {
+  bucket_prefix = "${var.name}-results-"
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "results" {
+  bucket = aws_s3_bucket.results.id
+
+  # Scan reports name the domains an organisation is defending, which reveals
+  # both what they own and what they are worried about. This bucket is never
+  # public.
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "results" {
+  bucket = aws_s3_bucket.results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.kms_key_arn == null ? "AES256" : "aws:kms"
+      kms_master_key_id = var.kms_key_arn
+    }
+    bucket_key_enabled = var.kms_key_arn != null
+  }
+}
+
+resource "aws_s3_bucket_versioning" "results" {
+  bucket = aws_s3_bucket.results.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "results" {
+  count  = var.results_retention_days > 0 ? 1 : 0
+  bucket = aws_s3_bucket.results.id
+
+  rule {
+    id     = "expire-reports"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      days = var.results_retention_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.results]
+}
+
+# --- Scan state --------------------------------------------------------------
+#
+# This is the part that is easy to get wrong, and getting it wrong is silent.
+#
+# Typo Sniper detects *changes* by comparing each scan against the previous
+# one, and it keeps that history in a local directory. A scheduled container
+# on ephemeral storage therefore starts from nothing every run: every scan
+# looks like a first run, no deltas are ever computed, and no alert ever
+# fires. The scanner appears to work perfectly while doing none of the job it
+# was deployed for.
+#
+# EFS gives the task a directory that survives between runs. It is mounted by
+# both the ECS and EKS variants for exactly this reason.
+
+resource "aws_efs_file_system" "state" {
+  creation_token = "${var.name}-state"
+  encrypted      = true
+  kms_key_id     = var.kms_key_arn
+
+  # Scan history is small — tens of KB per monitored domain — and read once
+  # per run, so bursting throughput is both sufficient and cheapest.
+  throughput_mode = "bursting"
+
+  lifecycle_policy {
+    transition_to_ia = "AFTER_30_DAYS"
+  }
+
+  tags = merge(local.tags, { Name = "${var.name}-state" })
+}
+
+resource "aws_efs_backup_policy" "state" {
+  file_system_id = aws_efs_file_system.state.id
+
+  backup_policy {
+    # Losing scan history means losing the baseline every alert is measured
+    # against: the next run reports every known lookalike as new.
+    status = "ENABLED"
+  }
+}
+
+resource "aws_security_group" "efs" {
+  name_prefix = "${var.name}-efs-"
+  description = "NFS access to the Typo Sniper state file system"
+  vpc_id      = var.vpc_id
+
+  tags = merge(local.tags, { Name = "${var.name}-efs" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "task" {
+  name_prefix = "${var.name}-task-"
+  description = "Typo Sniper scan task"
+  vpc_id      = var.vpc_id
+
+  # The scanner's whole job is reaching DNS, RDAP, WHOIS and suspicious hosts,
+  # so egress is open. Nothing needs to reach *in*: there is no listener.
+  egress {
+    description = "Outbound scanning and API traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, { Name = "${var.name}-task" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "efs_from_task" {
+  description              = "NFS from the scan task only"
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.efs.id
+  source_security_group_id = aws_security_group.task.id
+}
+
+resource "aws_efs_mount_target" "state" {
+  for_each = toset(var.subnet_ids)
+
+  file_system_id  = aws_efs_file_system.state.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs.id]
+}
+
+resource "aws_efs_access_point" "state" {
+  file_system_id = aws_efs_file_system.state.id
+
+  # The container runs as uid 10001 (see docker/Dockerfile). The access point
+  # owns the directory as that user so the task never needs root to write.
+  posix_user {
+    uid = 10001
+    gid = 10001
+  }
+
+  root_directory {
+    path = "/typo-sniper"
+
+    creation_info {
+      owner_uid   = 10001
+      owner_gid   = 10001
+      permissions = "0755"
+    }
+  }
+
+  tags = merge(local.tags, { Name = "${var.name}-state" })
+}
+
+# --- Credentials -------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "app" {
+  name_prefix = "${var.name}/"
+  description = "Typo Sniper API keys, webhook URLs and SMTP credentials"
+  kms_key_id  = var.kms_key_arn
+
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "app" {
+  secret_id = aws_secretsmanager_secret.app.id
+
+  # A placeholder so the secret exists and the task can start. Populate the
+  # real values out of band — putting them in Terraform would write them to
+  # state in clear text, which is the thing the secrets backend exists to
+  # avoid. Keys match Typo Sniper's own names; see
+  # docs/guides/SECRETS_MANAGEMENT.md.
+  secret_string = jsonencode({
+    urlscan_api_key = ""
+  })
+
+  lifecycle {
+    # Never overwrite values an operator has set by hand or by rotation.
+    ignore_changes = [secret_string]
+  }
+}

--- a/infra/terraform/modules/common/outputs.tf
+++ b/infra/terraform/modules/common/outputs.tf
@@ -1,0 +1,44 @@
+output "results_bucket" {
+  description = "S3 bucket holding scan reports."
+  value       = aws_s3_bucket.results.id
+}
+
+output "results_bucket_arn" {
+  description = "ARN of the results bucket."
+  value       = aws_s3_bucket.results.arn
+}
+
+output "state_file_system_id" {
+  description = "EFS file system holding scan history."
+  value       = aws_efs_file_system.state.id
+}
+
+output "state_access_point_id" {
+  description = "EFS access point the task mounts."
+  value       = aws_efs_access_point.state.id
+}
+
+output "state_access_point_arn" {
+  description = "ARN of the EFS access point, for IAM conditions."
+  value       = aws_efs_access_point.state.arn
+}
+
+output "task_security_group_id" {
+  description = "Security group to attach to the scan task."
+  value       = aws_security_group.task.id
+}
+
+output "secret_arn" {
+  description = "Secrets Manager secret holding API keys and webhook URLs."
+  value       = aws_secretsmanager_secret.app.arn
+}
+
+output "secret_name" {
+  description = "Secret name, for TYPO_SNIPER_AWS_SECRET_NAME."
+  value       = aws_secretsmanager_secret.app.name
+}
+
+output "tags" {
+  description = "Merged tag set, for reuse by the deployment modules."
+  value       = local.tags
+}

--- a/infra/terraform/modules/common/variables.tf
+++ b/infra/terraform/modules/common/variables.tf
@@ -1,0 +1,54 @@
+variable "name" {
+  description = "Name prefix for every resource this module creates."
+  type        = string
+  default     = "typo-sniper"
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{1,30}$", var.name))
+    error_message = "name must be lowercase alphanumeric with hyphens, 2-31 characters."
+  }
+}
+
+variable "vpc_id" {
+  description = <<-EOT
+    VPC to place the EFS mount targets in. Not created here: a module that
+    invents a VPC is almost always wrong for an existing account, and the
+    scanner only needs outbound access.
+  EOT
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = <<-EOT
+    Subnets for EFS mount targets and for the scan task. These need a route to
+    the internet (NAT gateway, or public subnets with a public IP assigned) —
+    the scanner's entire job is reaching DNS, RDAP, and suspicious hosts.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.subnet_ids) > 0
+    error_message = "at least one subnet is required."
+  }
+}
+
+variable "results_retention_days" {
+  description = "Days to keep scan reports in S3 before expiry. 0 disables expiry."
+  type        = number
+  default     = 90
+}
+
+variable "kms_key_arn" {
+  description = <<-EOT
+    Customer-managed KMS key for the S3 bucket, the EFS file system, and the
+    secret. Null uses AWS-managed keys, which is fine for most deployments.
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to every resource."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/terraform/modules/common/versions.tf
+++ b/infra/terraform/modules/common/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      # >= 6.0: the aws_region data source exposes `region` from v6 onward,
+      # where v5 spelled it `name`. Pinning the major keeps the attribute
+      # unambiguous rather than depending on what resolves at init time.
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/infra/terraform/modules/ecs-fargate/iam.tf
+++ b/infra/terraform/modules/ecs-fargate/iam.tf
@@ -1,0 +1,148 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# --- Execution role: what ECS itself needs to start the task -----------------
+
+data "aws_iam_policy_document" "execution_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name_prefix        = "${var.name}-exec-"
+  assume_role_policy = data.aws_iam_policy_document.execution_assume.json
+  tags               = var.common.tags
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# --- Task role: what the scanner itself may do -------------------------------
+
+data "aws_iam_policy_document" "task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task" {
+  name_prefix        = "${var.name}-task-"
+  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+  tags               = var.common.tags
+}
+
+data "aws_iam_policy_document" "task" {
+  # Reports go up; nothing is ever read back or deleted. A compromised scan
+  # task should not be able to read another run's findings, so no s3:GetObject.
+  statement {
+    sid       = "WriteReports"
+    actions   = ["s3:PutObject"]
+    resources = ["${var.common.results_bucket_arn}/*"]
+  }
+
+  # One specific secret, not "read every secret in the account".
+  statement {
+    sid       = "ReadOwnSecret"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [var.common.secret_arn]
+  }
+
+  statement {
+    sid = "MountStateFileSystem"
+
+    actions = [
+      "elasticfilesystem:ClientMount",
+      "elasticfilesystem:ClientWrite",
+    ]
+
+    resources = ["arn:aws:elasticfilesystem:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:file-system/${var.common.state_file_system_id}"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "elasticfilesystem:AccessPointArn"
+      values   = [var.common.state_access_point_arn]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "task" {
+  name_prefix = "${var.name}-task-"
+  role        = aws_iam_role.task.id
+  policy      = data.aws_iam_policy_document.task.json
+}
+
+# --- Scheduler role: what EventBridge may start ------------------------------
+
+data "aws_iam_policy_document" "scheduler_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
+
+    # Without this, any account able to reach the scheduler service could
+    # assume this role: the classic confused deputy.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "scheduler" {
+  name_prefix        = "${var.name}-sched-"
+  assume_role_policy = data.aws_iam_policy_document.scheduler_assume.json
+  tags               = var.common.tags
+}
+
+data "aws_iam_policy_document" "scheduler" {
+  statement {
+    sid       = "RunScanTask"
+    actions   = ["ecs:RunTask"]
+    resources = ["${aws_ecs_task_definition.scan.arn_without_revision}:*"]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "ecs:cluster"
+      values   = [local.cluster_arn]
+    }
+  }
+
+  statement {
+    sid     = "PassTaskRoles"
+    actions = ["iam:PassRole"]
+
+    resources = [
+      aws_iam_role.execution.arn,
+      aws_iam_role.task.arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "scheduler" {
+  name_prefix = "${var.name}-sched-"
+  role        = aws_iam_role.scheduler.id
+  policy      = data.aws_iam_policy_document.scheduler.json
+}

--- a/infra/terraform/modules/ecs-fargate/main.tf
+++ b/infra/terraform/modules/ecs-fargate/main.tf
@@ -1,0 +1,152 @@
+# A scheduled Fargate task.
+#
+# This shape is chosen deliberately. Typo Sniper is a batch job: it wakes up,
+# scans for a few minutes, writes a report, and exits. Fargate bills for those
+# minutes and nothing else, and there is no cluster sitting idle between runs.
+
+locals {
+  cluster_arn  = var.cluster_arn != null ? var.cluster_arn : aws_ecs_cluster.this[0].arn
+  domains_file = "/app/data/monitored_domains.txt"
+  state_dir    = "/app/state"
+
+  # Written by the entrypoint before the scan starts, so the monitored list is
+  # Terraform-managed rather than baked into the image.
+  bootstrap = join(" && ", [
+    "printf '%s\\n' ${join(" ", [for d in var.domains : format("%q", d)])} > ${local.domains_file}",
+    "typo-sniper ${join(" ", concat(["-i", local.domains_file, "--output", "/app/results"], var.extra_args))}",
+    # Shipped in the image; see docker/upload-results.py. Reads
+    # RESULTS_BUCKET and RESULTS_PREFIX from the environment below.
+    "typo-sniper-upload",
+  ])
+}
+
+resource "aws_ecs_cluster" "this" {
+  count = var.cluster_arn == null ? 1 : 0
+
+  name = var.name
+  tags = var.common.tags
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "scan" {
+  name_prefix       = "/ecs/${var.name}-"
+  retention_in_days = var.log_retention_days
+  tags              = var.common.tags
+}
+
+resource "aws_ecs_task_definition" "scan" {
+  family                   = var.name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+  tags                     = var.common.tags
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  volume {
+    name = "state"
+
+    efs_volume_configuration {
+      file_system_id     = var.common.state_file_system_id
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = var.common.state_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "scan"
+      image     = var.image
+      essential = true
+
+      # The image's entrypoint is the typo-sniper console script, so it is
+      # overridden here to write the domain list first and ship results after.
+      entryPoint = ["/bin/sh", "-c"]
+      command    = [local.bootstrap]
+
+      mountPoints = [
+        {
+          sourceVolume  = "state"
+          containerPath = local.state_dir
+          readOnly      = false
+        }
+      ]
+
+      environment = [
+        # Resolves credentials through the AWS Secrets Manager backend rather
+        # than baking them into the task definition, where they would be
+        # readable by anyone with ecs:DescribeTaskDefinition.
+        { name = "TYPO_SNIPER_AWS_SECRET_NAME", value = var.common.secret_name },
+        { name = "AWS_REGION", value = data.aws_region.current.region },
+        { name = "TYPO_SNIPER_STATE_DIR", value = local.state_dir },
+        { name = "TYPO_SNIPER_OUTPUT_DIR", value = "/app/results" },
+        { name = "RESULTS_BUCKET", value = var.common.results_bucket },
+        { name = "RESULTS_PREFIX", value = var.name },
+        { name = "PYTHONUNBUFFERED", value = "1" },
+      ]
+
+      readonlyRootFilesystem = false # results and the domain list are written
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.scan.name
+          "awslogs-region"        = data.aws_region.current.region
+          "awslogs-stream-prefix" = "scan"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_scheduler_schedule" "scan" {
+  name       = var.name
+  group_name = "default"
+
+  flexible_time_window {
+    # A scan is not time-critical to the minute, and a window lets AWS spread
+    # load rather than starting every scheduled task in the account at once.
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 15
+  }
+
+  schedule_expression          = var.schedule_expression
+  schedule_expression_timezone = "UTC"
+
+  target {
+    arn      = local.cluster_arn
+    role_arn = aws_iam_role.scheduler.arn
+
+    ecs_parameters {
+      task_definition_arn = aws_ecs_task_definition.scan.arn_without_revision
+      launch_type         = "FARGATE"
+      task_count          = 1
+      propagate_tags      = "TASK_DEFINITION"
+
+      network_configuration {
+        subnets          = var.subnet_ids
+        security_groups  = [var.common.task_security_group_id]
+        assign_public_ip = var.assign_public_ip
+      }
+    }
+
+    retry_policy {
+      maximum_retry_attempts       = 2
+      maximum_event_age_in_seconds = var.task_timeout_hours * 3600
+    }
+  }
+}

--- a/infra/terraform/modules/ecs-fargate/outputs.tf
+++ b/infra/terraform/modules/ecs-fargate/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_arn" {
+  description = "ECS cluster the scan runs in."
+  value       = local.cluster_arn
+}
+
+output "task_definition_arn" {
+  description = "Task definition, for running a scan by hand."
+  value       = aws_ecs_task_definition.scan.arn
+}
+
+output "task_role_arn" {
+  description = "Role the scanner itself assumes."
+  value       = aws_iam_role.task.arn
+}
+
+output "log_group" {
+  description = "CloudWatch log group holding scan output."
+  value       = aws_cloudwatch_log_group.scan.name
+}
+
+output "schedule_name" {
+  description = "EventBridge schedule driving the scan."
+  value       = aws_scheduler_schedule.scan.name
+}

--- a/infra/terraform/modules/ecs-fargate/variables.tf
+++ b/infra/terraform/modules/ecs-fargate/variables.tf
@@ -1,0 +1,105 @@
+variable "name" {
+  description = "Name prefix for every resource this module creates."
+  type        = string
+  default     = "typo-sniper"
+}
+
+variable "image" {
+  description = <<-EOT
+    Container image to run. Pin a version tag rather than :latest — a scheduled
+    job silently picking up a new image is how a scan starts failing at 3am
+    with nothing in the change log to explain it.
+  EOT
+  type        = string
+  default     = "ghcr.io/chiefgyk3d/typo-sniper:2.1.0"
+}
+
+variable "schedule_expression" {
+  description = "EventBridge schedule. Default is daily at 06:00 UTC."
+  type        = string
+  default     = "cron(0 6 * * ? *)"
+}
+
+variable "domains" {
+  description = <<-EOT
+    Domains to monitor. Written into the task definition as a file the
+    entrypoint reads, so changing this list is a Terraform apply rather than a
+    rebuild of the image.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.domains) > 0
+    error_message = "at least one domain to monitor is required."
+  }
+}
+
+variable "extra_args" {
+  description = "Additional CLI arguments, e.g. [\"--notify\", \"slack\"]."
+  type        = list(string)
+  default     = []
+}
+
+variable "cluster_arn" {
+  description = "Existing ECS cluster to run in. Null creates a dedicated one."
+  type        = string
+  default     = null
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units. 1024 = 1 vCPU."
+  type        = number
+  default     = 1024
+}
+
+variable "memory" {
+  description = "Fargate task memory in MiB."
+  type        = number
+  default     = 2048
+}
+
+variable "task_timeout_hours" {
+  description = <<-EOT
+    Hours before a stuck scan is considered failed. Fargate has no task
+    timeout of its own, so this drives the EventBridge retry policy. Note this
+    is one reason Lambda is not offered: a scan of a large brand routinely
+    exceeds Lambda's 15-minute ceiling.
+  EOT
+  type        = number
+  default     = 4
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention."
+  type        = number
+  default     = 30
+}
+
+variable "assign_public_ip" {
+  description = <<-EOT
+    Give the task a public IP. Required when running in public subnets without
+    a NAT gateway; the scanner cannot work without outbound access.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "subnet_ids" {
+  description = "Subnets to run the task in."
+  type        = list(string)
+}
+
+variable "common" {
+  description = "The entire output object of the `common` module."
+  type = object({
+    results_bucket         = string
+    results_bucket_arn     = string
+    state_file_system_id   = string
+    state_access_point_id  = string
+    state_access_point_arn = string
+    task_security_group_id = string
+    secret_arn             = string
+    secret_name            = string
+    tags                   = map(string)
+  })
+}

--- a/infra/terraform/modules/ecs-fargate/versions.tf
+++ b/infra/terraform/modules/ecs-fargate/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      # >= 6.0: the aws_region data source exposes `region` from v6 onward,
+      # where v5 spelled it `name`. Pinning the major keeps the attribute
+      # unambiguous rather than depending on what resolves at init time.
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/infra/terraform/modules/eks-cronjob/main.tf
+++ b/infra/terraform/modules/eks-cronjob/main.tf
@@ -1,0 +1,320 @@
+# A Kubernetes CronJob on an existing EKS cluster.
+#
+# The same workload as the ECS variant, for teams whose scheduling, alerting
+# and on-call already run through Kubernetes. It shares the `common` module,
+# so both shapes write to the same bucket and read the same secret; the
+# difference is only what starts the container.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  labels = {
+    "app.kubernetes.io/name"       = "typo-sniper"
+    "app.kubernetes.io/component"  = "scanner"
+    "app.kubernetes.io/managed-by" = "terraform"
+  }
+
+  domains_path = "/app/data/monitored_domains.txt"
+  state_dir    = "/app/state"
+}
+
+# --- IRSA: the pod's AWS identity --------------------------------------------
+
+data "aws_iam_policy_document" "irsa_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+
+    # Scoped to this one service account. Without the `sub` condition any pod
+    # in the cluster could assume the role.
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc_provider_url}:sub"
+      values   = ["system:serviceaccount:${var.namespace}:${var.name}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc_provider_url}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "irsa" {
+  name_prefix        = "${var.name}-irsa-"
+  assume_role_policy = data.aws_iam_policy_document.irsa_assume.json
+  tags               = var.common.tags
+}
+
+data "aws_iam_policy_document" "irsa" {
+  # Reports go up; nothing is read back or deleted.
+  statement {
+    sid       = "WriteReports"
+    actions   = ["s3:PutObject"]
+    resources = ["${var.common.results_bucket_arn}/*"]
+  }
+
+  statement {
+    sid       = "ReadOwnSecret"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [var.common.secret_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "irsa" {
+  name_prefix = "${var.name}-irsa-"
+  role        = aws_iam_role.irsa.id
+  policy      = data.aws_iam_policy_document.irsa.json
+}
+
+resource "kubernetes_service_account_v1" "scanner" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+    labels    = local.labels
+
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.irsa.arn
+    }
+  }
+}
+
+# --- Scan state ---------------------------------------------------------------
+#
+# Same reasoning as the ECS variant: Typo Sniper detects changes by comparing
+# each scan against the last, and keeps that history on disk. A CronJob pod
+# starts with an empty filesystem, so without a persistent volume every run
+# looks like a first run and no delta is ever reported. The scanner would
+# appear to work while doing none of the job it was deployed for.
+
+resource "kubernetes_persistent_volume_v1" "state" {
+  metadata {
+    name   = "${var.name}-state"
+    labels = local.labels
+  }
+
+  spec {
+    capacity = {
+      # EFS is elastic; the CSI driver requires a value but does not enforce it.
+      storage = "8Gi"
+    }
+
+    access_modes                     = ["ReadWriteMany"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = var.efs_csi_storage_class
+
+    persistent_volume_source {
+      csi {
+        driver = "efs.csi.aws.com"
+        # The access point pins the uid/gid and root directory, so the pod
+        # writes as 10001 without needing root.
+        volume_handle = "${var.common.state_file_system_id}::${var.common.state_access_point_id}"
+      }
+    }
+  }
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "state" {
+  metadata {
+    name      = "${var.name}-state"
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    access_modes       = ["ReadWriteMany"]
+    storage_class_name = var.efs_csi_storage_class
+    volume_name        = kubernetes_persistent_volume_v1.state.metadata[0].name
+
+    resources {
+      requests = {
+        storage = "8Gi"
+      }
+    }
+  }
+}
+
+# --- Monitored domains --------------------------------------------------------
+
+resource "kubernetes_config_map_v1" "domains" {
+  metadata {
+    name      = "${var.name}-domains"
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  data = {
+    # Terraform-managed rather than baked into the image, so changing the list
+    # is an apply rather than a rebuild.
+    "monitored_domains.txt" = join("\n", var.domains)
+  }
+}
+
+# --- The job ------------------------------------------------------------------
+
+resource "kubernetes_cron_job_v1" "scan" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    schedule                      = var.schedule
+    concurrency_policy            = "Forbid" # Two scans writing the same state would race
+    successful_jobs_history_limit = 3
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 3600
+
+    job_template {
+      metadata {
+        labels = local.labels
+      }
+
+      spec {
+        backoff_limit           = 2
+        active_deadline_seconds = var.active_deadline_seconds
+
+        template {
+          metadata {
+            labels = local.labels
+          }
+
+          spec {
+            service_account_name = kubernetes_service_account_v1.scanner.metadata[0].name
+            restart_policy       = "OnFailure"
+
+            security_context {
+              # Matches the uid the image and the EFS access point use.
+              run_as_non_root = true
+              run_as_user     = 10001
+              run_as_group    = 10001
+              fs_group        = 10001
+            }
+
+            container {
+              name  = "scan"
+              image = var.image
+
+              command = ["/bin/sh", "-c"]
+              args = [
+                join(" && ", [
+                  "typo-sniper ${join(" ", concat(["-i", local.domains_path, "--output", "/app/results"], var.extra_args))}",
+                  # Shipped in the image; see docker/upload-results.py.
+                  "typo-sniper-upload",
+                ])
+              ]
+
+              env {
+                # Credentials come from Secrets Manager through the scanner's
+                # own backend chain, using the IRSA identity above.
+                name  = "TYPO_SNIPER_AWS_SECRET_NAME"
+                value = var.common.secret_name
+              }
+
+              env {
+                name  = "AWS_REGION"
+                value = data.aws_region.current.region
+              }
+
+              env {
+                name  = "TYPO_SNIPER_STATE_DIR"
+                value = local.state_dir
+              }
+
+              env {
+                name  = "TYPO_SNIPER_OUTPUT_DIR"
+                value = "/app/results"
+              }
+
+              env {
+                name  = "RESULTS_BUCKET"
+                value = var.common.results_bucket
+              }
+
+              env {
+                name  = "RESULTS_PREFIX"
+                value = var.name
+              }
+
+              env {
+                name  = "PYTHONUNBUFFERED"
+                value = "1"
+              }
+
+              resources {
+                requests = {
+                  cpu    = var.cpu_request
+                  memory = var.memory_request
+                }
+
+                limits = {
+                  # No CPU limit on purpose: throttling a scan makes it slower,
+                  # not safer, and the job is bounded by its deadline anyway.
+                  memory = var.memory_limit
+                }
+              }
+
+              security_context {
+                allow_privilege_escalation = false
+                read_only_root_filesystem  = false # results are written
+
+                capabilities {
+                  drop = ["ALL"]
+                }
+              }
+
+              volume_mount {
+                name       = "state"
+                mount_path = local.state_dir
+              }
+
+              volume_mount {
+                name       = "domains"
+                mount_path = "/app/data"
+                read_only  = true
+              }
+
+              volume_mount {
+                name       = "results"
+                mount_path = "/app/results"
+              }
+            }
+
+            volume {
+              name = "state"
+
+              persistent_volume_claim {
+                claim_name = kubernetes_persistent_volume_claim_v1.state.metadata[0].name
+              }
+            }
+
+            volume {
+              name = "domains"
+
+              config_map {
+                name = kubernetes_config_map_v1.domains.metadata[0].name
+              }
+            }
+
+            volume {
+              name = "results"
+
+              empty_dir {
+                # Reports are shipped to S3 at the end of the run, so this only
+                # has to survive the pod.
+                size_limit = "1Gi"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/terraform/modules/eks-cronjob/outputs.tf
+++ b/infra/terraform/modules/eks-cronjob/outputs.tf
@@ -1,0 +1,19 @@
+output "cron_job_name" {
+  description = "Kubernetes CronJob running the scan."
+  value       = kubernetes_cron_job_v1.scan.metadata[0].name
+}
+
+output "service_account_name" {
+  description = "Service account the pod runs as."
+  value       = kubernetes_service_account_v1.scanner.metadata[0].name
+}
+
+output "irsa_role_arn" {
+  description = "IAM role the pod assumes via IRSA."
+  value       = aws_iam_role.irsa.arn
+}
+
+output "state_claim_name" {
+  description = "PVC holding scan history between runs."
+  value       = kubernetes_persistent_volume_claim_v1.state.metadata[0].name
+}

--- a/infra/terraform/modules/eks-cronjob/variables.tf
+++ b/infra/terraform/modules/eks-cronjob/variables.tf
@@ -1,0 +1,111 @@
+variable "name" {
+  description = "Name prefix for Kubernetes and AWS resources."
+  type        = string
+  default     = "typo-sniper"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace to deploy into. Must already exist."
+  type        = string
+  default     = "security"
+}
+
+variable "image" {
+  description = <<-EOT
+    Container image to run. Pin a version tag rather than :latest — a
+    scheduled job silently picking up a new image is how a scan starts failing
+    at 3am with nothing in the change log to explain it.
+  EOT
+  type        = string
+  default     = "ghcr.io/chiefgyk3d/typo-sniper:2.1.0"
+}
+
+variable "schedule" {
+  description = "Kubernetes CronJob schedule, in cluster time. Daily at 06:00."
+  type        = string
+  default     = "0 6 * * *"
+}
+
+variable "domains" {
+  description = "Domains to monitor. Mounted as a ConfigMap."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.domains) > 0
+    error_message = "at least one domain to monitor is required."
+  }
+}
+
+variable "extra_args" {
+  description = "Additional CLI arguments, e.g. [\"--notify\", \"slack\"]."
+  type        = list(string)
+  default     = []
+}
+
+variable "oidc_provider_arn" {
+  description = <<-EOT
+    ARN of the cluster's IAM OIDC provider, for IRSA. From the aws_eks_cluster
+    data source or the terraform-aws-eks module's oidc_provider_arn output.
+
+    The cluster itself is deliberately not created here: most teams running
+    EKS already have one, and a scan job has no business owning a cluster.
+  EOT
+  type        = string
+}
+
+variable "oidc_provider_url" {
+  description = "Cluster OIDC issuer URL, without the https:// scheme."
+  type        = string
+}
+
+variable "efs_csi_storage_class" {
+  description = <<-EOT
+    StorageClass backed by the EFS CSI driver. The driver must already be
+    installed in the cluster; this module does not install it.
+  EOT
+  type        = string
+  default     = "efs-sc"
+}
+
+variable "cpu_request" {
+  description = "CPU request for the scan pod."
+  type        = string
+  default     = "500m"
+}
+
+variable "memory_request" {
+  description = "Memory request for the scan pod."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the scan pod."
+  type        = string
+  default     = "2Gi"
+}
+
+variable "active_deadline_seconds" {
+  description = <<-EOT
+    Seconds before a stuck scan is killed. A scan of a large brand takes
+    minutes, not hours; the default gives generous headroom while still
+    guaranteeing a hung run cannot block the next schedule forever.
+  EOT
+  type        = number
+  default     = 14400
+}
+
+variable "common" {
+  description = "The entire output object of the `common` module."
+  type = object({
+    results_bucket         = string
+    results_bucket_arn     = string
+    state_file_system_id   = string
+    state_access_point_id  = string
+    state_access_point_arn = string
+    task_security_group_id = string
+    secret_arn             = string
+    secret_name            = string
+    tags                   = map(string)
+  })
+}

--- a/infra/terraform/modules/eks-cronjob/versions.tf
+++ b/infra/terraform/modules/eks-cronjob/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.30"
+    }
+  }
+}

--- a/src/typo_sniper/config.py
+++ b/src/typo_sniper/config.py
@@ -213,6 +213,23 @@ class Config:
     
     def __post_init__(self):
         """Post-initialization: normalise paths and load secrets from environment."""
+        # Directory overrides from the environment. A container image ships a
+        # default and the deployment redirects it, so for these three the
+        # environment wins — unlike credentials, where an explicit config value
+        # is a deliberate act and takes precedence.
+        #
+        # state_dir especially: it holds the scan history every delta is
+        # computed against. Point it at ephemeral storage and the scanner still
+        # runs, still reports, and silently never detects a change again.
+        for attr, name in (
+            ('cache_dir', 'TYPO_SNIPER_CACHE_DIR'),
+            ('output_dir', 'TYPO_SNIPER_OUTPUT_DIR'),
+            ('state_dir', 'TYPO_SNIPER_STATE_DIR'),
+        ):
+            value = os.getenv(name)
+            if value:
+                setattr(self, attr, value)
+
         # Expand "~" and environment variables so that a config file containing
         # "cache_dir: ~/.typo_sniper/cache" does not create a literal "~"
         # directory in the working directory.

--- a/src/typo_sniper/version.py
+++ b/src/typo_sniper/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -176,3 +176,43 @@ class TestSecretResolution:
         config = Config()
         for attr, _aliases in Config.SECRET_FIELDS:
             assert hasattr(config, attr), attr
+
+
+class TestDirectoryOverrides:
+    """
+    Container deployments redirect these at runtime.
+
+    state_dir matters most: it holds the history every delta is computed
+    against. Point it at ephemeral storage and the scanner still runs, still
+    reports, and silently never detects a change again.
+    """
+
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch):
+        for key in ('TYPO_SNIPER_CACHE_DIR', 'TYPO_SNIPER_OUTPUT_DIR',
+                    'TYPO_SNIPER_STATE_DIR'):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_state_dir_from_environment(self, monkeypatch):
+        monkeypatch.setenv('TYPO_SNIPER_STATE_DIR', '/mnt/efs/state')
+        assert Config().state_dir == Path('/mnt/efs/state')
+
+    def test_output_dir_from_environment(self, monkeypatch):
+        monkeypatch.setenv('TYPO_SNIPER_OUTPUT_DIR', '/app/results')
+        assert Config().output_dir == Path('/app/results')
+
+    def test_cache_dir_from_environment(self, monkeypatch):
+        monkeypatch.setenv('TYPO_SNIPER_CACHE_DIR', '/app/cache')
+        assert Config().cache_dir == Path('/app/cache')
+
+    def test_the_environment_wins_over_a_config_value(self, monkeypatch):
+        """A deployment-time override is the whole point of these."""
+        monkeypatch.setenv('TYPO_SNIPER_STATE_DIR', '/mnt/efs/state')
+        assert Config(state_dir=Path('/somewhere/else')).state_dir == Path('/mnt/efs/state')
+
+    def test_overrides_are_still_expanded(self, monkeypatch):
+        monkeypatch.setenv('TYPO_SNIPER_STATE_DIR', '~/from-env')
+        assert '~' not in str(Config().state_dir)
+
+    def test_defaults_are_unchanged_without_the_variables(self):
+        assert '.typo_sniper' in str(Config().state_dir)


### PR DESCRIPTION
Both deployment shapes you picked, sharing one set of supporting resources. Fixes #10, which unblocks #11.

```
infra/terraform/
├── modules/
│   ├── common/        S3 reports, EFS state, Secrets Manager, security groups
│   ├── ecs-fargate/   Scheduled Fargate task via EventBridge Scheduler
│   └── eks-cronjob/   Kubernetes CronJob on an existing EKS cluster
└── examples/          Complete working deployments of each
```

Lambda is deliberately not offered: a scan of a well-known brand routinely runs past the 15-minute ceiling you flagged in the issue, and the failure mode is a truncated scan that looks like a clean one.

---

## The bug this work surfaced

**A containerised deployment would have silently stopped detecting changes.**

Typo Sniper compares each scan against the previous one and keeps that history in `state_dir` — which had **no environment override**. A container had no way to point it at a persistent volume without baking a config file into the image, so on ephemeral storage every scheduled run looks like a first run: no deltas computed, no alerts fired, and a scanner that appears to work perfectly while doing none of the job it was deployed for. Nothing errors. Nothing warns.

Found the honest way: the Terraform set `TYPO_SNIPER_STATE_DIR` and the application ignored it.

`state_dir`, `output_dir`, and `cache_dir` now read from the environment, and both modules mount **EFS** at `state_dir` with backups enabled. For these three the environment wins over a config value — unlike credentials, where an explicit setting is a deliberate act and takes precedence. An image ships a default; the deployment redirects it.

## Two more gaps found the same way

- **The image had no AWS client at all.** So on AWS the documented Secrets Manager backend resolved nothing and the scan would have run with no API keys, reporting no error. boto3 is now in the image — weighing ~90MB against a scanner that quietly runs unauthenticated, the megabytes lose.
- **`.dockerignore` excluded `docker/`**, which would have broken the build once the uploader script was copied in — exactly as it excluded `pyproject.toml` in #32. Caught this time by building the context *before* pushing rather than after CI failed.

Reports ship via `docker/upload-results.py` rather than an inline `python -c` in the task definition. That would have been a Python string inside a shell string inside JSON inside HCL, and every layer of escaping there is somewhere a bug hides silently.

## Permissions

The scan task can do three things:

- **`s3:PutObject`** to its own bucket. No `GetObject`, no `DeleteObject` — a compromised scan task should not be able to read another run's findings.
- **`secretsmanager:GetSecretValue`** on one named secret, not every secret in the account.
- **Mount one EFS access point**, conditioned on the access point ARN.

The scheduler role can start one task definition on one cluster and pass only the two roles that task needs, with its trust policy scoped by `aws:SourceAccount` to close the confused-deputy path. The EKS variant's IRSA trust is scoped to one service account in one namespace — without that condition any pod in the cluster could assume the role.

The secret is created empty and `ignore_changes` protects it. Putting credentials in a Terraform variable writes them to state in clear text, which is the thing a secrets backend exists to prevent.

## What it doesn't create

No VPC (a module that invents one is almost always wrong for an existing account), no EKS cluster, and no EFS CSI driver. A scan job has no business owning a cluster, and a CSI driver is a cluster-wide concern.

## Verification — please read this part

**Terraform is syntax-checked and canonically formatted, not schema-validated.** `tofu fmt` parses the HCL and rejects malformed configuration, which I confirmed by feeding it a deliberately broken file. But the provider registry is unreachable from this sandbox (403), so `tofu init` cannot run and therefore neither can `tofu validate` or `tofu plan`.

**Run `tofu validate` and `tofu plan` in your account before applying.** That will catch any argument a provider version rejects — the most likely class of remaining error. I pinned `aws >= 6.0` specifically because the `aws_region` data source renamed `name` to `region` in v6, and I did not want that resolving differently at init time.

What I *did* verify:
- `tofu fmt -check -recursive infra` — parses and formatted
- The uploader exercised against a stubbed boto3: nested paths, and both no-op cases (no bucket set, missing results dir)
- The Docker build context **built**, and the failure without the `.dockerignore` fix reproduced
- **581 tests pass** on Python 3.10 and 3.11, ruff clean
- Six new tests covering the directory overrides, including that the environment wins over a config value and that `~` still expands

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_