### PR TITLE
Bring the documentation up to date with the last nine releases (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to Typo Sniper are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-08-27
+
+Documentation catch-up. The feature list had not been touched since 1.1.0 while
+a dozen features landed behind it.
+
+### Added
+
+- **[docs/STATUS.md](docs/STATUS.md)** — an honest account of what has been
+  verified against real services and what has only ever run against tests and
+  stubs, with specific things to try and what to report.
+
+  Every feature has tests and the suite is hermetic, but a passing stub test
+  proves the code does what its author expected, not that a vendor's API
+  agrees. Several integrations have never had a request leave a developer's
+  machine: all six remote secrets backends, every AI provider, Teams, Matrix,
+  Jira, and the Terraform modules. The learned ranking model cannot be
+  evaluated by anyone yet, because it has no real labels.
+
+- A **Testing and Feedback Wanted** section at the top of the README pointing
+  at it, calling out the two highest-value asks: AWS Secrets Manager
+  (issue #5), and Jira against a scratch project, since it creates state.
+
+### Changed
+
+- **Rewrote the README feature list.** It described the tool as of 1.1.0 and
+  omitted change detection, notifications, ticketing, RDAP, mail intelligence,
+  the Public Suffix List, AI triage, learned ranking, page analysis, secrets
+  backends, and deployment. Added a summary table, a section on the signals
+  that indicate intent, and the two rules that govern the whole design: the AI
+  and ML layers explain and rank but never score, and a failed lookup is never
+  reported as a finding.
+
+- **Rebuilt the CLI options tables** from the actual parser, grouped by task.
+  Fourteen flags were missing, including every flag for monitoring, alerting,
+  AI, and learned ranking.
+
+- **Regenerated the project structure tree**, which still showed the pre-2.0.0
+  flat module layout.
+
+### Fixed
+
+- **Seven broken documentation links**, including two pointing at a guide that
+  never existed and four using paths relative to the repository root from files
+  inside `docs/guides/`. Verified by a link check across every Markdown file.
+
 ## [2.2.0] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 ## 📋 Table of Contents
 
 **Quick Navigation:**
+- [Testing and Feedback Wanted](#-testing-and-feedback-wanted) 🧪
 - [Documentation Guide](#-documentation-guide)
 - [Quick Start](#-quick-start) ⚡ **Start here!**
 - [Installation](#-installation)
@@ -48,6 +49,38 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 
 ---
 
+## 🧪 Testing and Feedback Wanted
+
+Typo Sniper gained a lot of surface area quickly — AI triage, learned ranking,
+seven secrets backends, seven alert channels, Jira ticketing, page analysis, and
+Terraform modules all landed recently.
+
+**Every feature has tests, and the suite is hermetic.** But a passing stub test
+proves the code does what its author expected, not that a vendor's API agrees.
+Several integrations have never had a request leave a developer's machine:
+Doppler, AWS, Vault, Azure, GCP, 1Password, every AI provider, Teams, Matrix,
+Jira, and the Terraform modules.
+
+👉 **[docs/STATUS.md](docs/STATUS.md)** is an honest account of what is verified
+and what is not, with specific things to try.
+
+If you test any of it, **please open an issue either way** — "this worked
+exactly as documented" is as useful as a bug report, and much rarer. Two asks in
+particular:
+
+- **[#5](https://github.com/ChiefGyk3D/typo-sniper/issues/5)** — anyone with an
+  AWS account to confirm Secrets Manager resolution
+- **Jira** — test against a scratch project first; it creates state
+
+And one thing nobody can evaluate yet, including the author: **the learned
+ranking model has no real labels.** It cannot be judged until someone makes
+~30 real triage decisions and runs `--ml-status`. An unremarkable score there is
+a legitimate result worth reporting.
+
+**[⬆ Back to Top](#-table-of-contents)**
+
+---
+
 ## 📚 Documentation Guide
 
 **New to Typo Sniper?** Start here:
@@ -57,7 +90,6 @@ Detect and monitor typosquatting domains targeting your brand with powerful auto
 
 | **[Quick Start Guide](docs/guides/QUICKSTART.md)** | 🚀 **Start here!** 10-minute guide to get running | First time setup, testing features |
 | **[README.md](README.md)** | 📖 **You are here.** Complete overview and reference | Understanding features, basic usage |
-| **[Enhancements](docs/guides/ENHANCEMENTS.md)** | 🔬 Deep dive into enhanced detection & threat intel | Understanding detection algorithms |
 | **[Testing Guide](TESTING.md)** | 🧪 Comprehensive testing guide with API setup | Setting up APIs, troubleshooting |
 | **[Debug Mode Guide](docs/guides/DEBUG_MODE.md)** | 🐛 Debug mode and troubleshooting guide | Troubleshooting, understanding what's running |
 | **[Secrets Management](docs/guides/SECRETS_MANAGEMENT.md)** | 🔐 Complete secrets management guide | Choosing secrets solution, security |
@@ -157,40 +189,52 @@ ruff check src/ tests/
 
 ```
 typo-sniper/
-├── src/                           # Core Python source code
-│   ├── __init__.py                # Package initialization
-│   ├── cache.py                   # Caching system
-│   ├── config.py                  # Configuration management
-│   ├── exporters.py               # Output format exporters (Excel, JSON, CSV, HTML)
-│   ├── scanner.py                 # Domain scanning & WHOIS enrichment
-│   ├── enhanced_detection.py      # 🆕 Advanced detection algorithms
-│   ├── threat_intelligence.py     # 🆕 Threat intel integrations
-│   ├── secrets_manager.py         # 🆕 Secrets management
-│   └── typo_sniper/              # The installable package
-│       ├── cli.py                # Application & CLI entry point
-│   ├── utils.py                   # Utility functions
-│   └── monitored_domains.txt      # Example domain list
-├── docker/                        # Docker-related files
-│   ├── Dockerfile                 # Standard Docker image
-│   ├── Dockerfile.doppler         # 🆕 Docker with Doppler support
-│   ├── docker-compose.yml         # Docker Compose configuration
-│   ├── docker-compose.threat-intel.yml  # 🆕 Compose with threat intel
-│   ├── .dockerignore              # Docker build exclusions
-│   ├── .env.example               # 🆕 Environment variables template
-│   └── DOCKER.md                  # Docker usage guide
-├── tests/                         # Unit tests
-│   └── __init__.py                # Test package initialization
-├── docs/                          # Documentation & configs
-│   ├── LICENSE                    # GNU AGPL v3
-│   └── config.yaml.example        # Example configuration
-├── QUICKSTART.md                  # 🆕 Quick start guide (start here!)
-├── TESTING.md                     # 🆕 Testing & API setup guide
-<!-- SECRETS_MANAGEMENT.md has been removed from the project structure -->
-├── ENHANCEMENTS.md                # 🆕 Feature documentation
-├── PROJECT_STRUCTURE.md           # Project organization
-├── requirements.txt               # Python dependencies
-├── .gitignore                     # Git ignore rules
-└── README.md                      # This file
+├── src/typo_sniper/               # The installable package
+│   ├── cli.py                     # Application and CLI entry point
+│   ├── __main__.py                # python -m typo_sniper
+│   ├── scanner.py                 # Scanning, permutations, enrichment
+│   ├── enhanced_detection.py      # Combo-squat, sound-alike, IDN homographs
+│   ├── rdap.py                    # RDAP client (WHOIS replacement over HTTPS)
+│   ├── dns_intel.py               # SPF / DKIM / DMARC mail posture
+│   ├── page_analysis.py           # Credential forms, off-site actions
+│   ├── threat_intelligence.py     # URLScan, CT logs, HTTP probing, risk score
+│   ├── state.py                   # Scan history and change detection
+│   ├── notifiers.py               # Slack, Discord, Teams, Matrix, Jira, …
+│   ├── exporters.py               # Excel, JSON, CSV, HTML reports
+│   ├── secrets_manager.py         # env, Doppler, AWS, Vault, Azure, GCP, 1Password
+│   ├── config.py                  # Configuration and secret resolution
+│   ├── cache.py                   # WHOIS/RDAP cache
+│   ├── utils.py                   # Validation, sanitisation, helpers
+│   ├── ai/                        # AI triage (explains, never scores)
+│   │   ├── analyzer.py            # Orchestration
+│   │   ├── prompts.py             # Prompt building and injection defences
+│   │   ├── providers.py           # Claude, OpenAI, Gemini, Ollama
+│   │   └── base.py                # Provider interface
+│   └── ml/                        # Learned ranking (ranks, never scores)
+│       ├── features.py            # Deterministic feature extraction
+│       ├── labels.py              # Operator decisions as training data
+│       ├── dataset.py             # Joins history to labels
+│       └── model.py               # Train (sklearn) / score (pure Python)
+├── infra/terraform/               # Deployment infrastructure
+│   ├── modules/common/            # S3, EFS state, secrets, security groups
+│   ├── modules/ecs-fargate/       # Scheduled Fargate task
+│   ├── modules/eks-cronjob/       # Kubernetes CronJob
+│   └── examples/                  # Runnable examples for both
+├── docker/                        # Container images and compose files
+├── tests/
+│   ├── unit/                      # Automated tests (hermetic, no network)
+│   ├── scripts/                   # Manual walkthroughs (need keys/network)
+│   └── test_data/                 # Fixtures
+├── docs/
+│   ├── STATUS.md                  # What is verified, what needs testing
+│   ├── guides/                    # Per-feature guides
+│   └── config.yaml.example        # Full configuration reference
+├── .github/workflows/             # CI, security scanning, release
+├── pyproject.toml                 # Packaging, extras, tool config
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── COMMERCIAL.md                  # Commercial licensing terms
+└── LICENSE                        # GNU AGPL v3
 ```
 
 **[⬆ Back to Top](#-table-of-contents)**
@@ -199,68 +243,105 @@ typo-sniper/
 
 ## 🎯 Features
 
+Everything below the Core row is optional and off unless configured. The
+scanner's detection and risk scoring are deterministic and run identically with
+every optional feature disabled.
+
+| Area | What you get | Guide |
+|---|---|---|
+| **Detection** | dnstwist permutations, combo-squatting, sound-alike, IDN homographs | [below](#enhanced-detection-methods-optional) |
+| **Registration** | RDAP first (HTTPS, works where port 43 is blocked), WHOIS fallback | — |
+| **Mail posture** | SPF / DKIM / DMARC classified `none` → `hardened` | — |
+| **Page analysis** | Credential forms, off-site form actions, brand mentions | [below](#-page-analysis) |
+| **Threat intel** | URLScan.io, Certificate Transparency, HTTP/TLS probing | [API Keys](docs/guides/API_KEYS_SETUP.md) |
+| **Change detection** | Diffs each scan against the last: new / escalated / activated / resolved | — |
+| **Alerting** | Slack, Discord, Teams, Matrix, webhook, email | [Alerting](docs/guides/ALERTING.md) |
+| **Ticketing** | Jira — one deduplicated issue per domain | [Alerting](docs/guides/ALERTING.md) |
+| **AI triage** | Claude, OpenAI, Gemini, Ollama — explains, never scores | [AI Analysis](docs/guides/AI_ANALYSIS.md) |
+| **Learned ranking** | Orders findings by your own past decisions | [ML Triage](docs/guides/ML_TRIAGE.md) |
+| **Secrets** | env, Doppler, AWS, Vault, Azure, GCP, 1Password | [Secrets](docs/guides/SECRETS_MANAGEMENT.md) |
+| **Deployment** | PyPI, GHCR container, Terraform for ECS Fargate and EKS | [Infrastructure](infra/README.md) |
+| **Reports** | Excel, JSON, CSV, HTML | [below](#-output-formats) |
+
 ### Core Capabilities
-- **Comprehensive Detection** - Uses [dnstwist](https://github.com/elceef/dnstwist) for industry-leading typosquatting detection
-- **Rich WHOIS Data** - Automatically enriches results with detailed WHOIS information
-- **Async & Parallel** - Fast concurrent scanning with configurable worker pools
-- **Smart Caching** - Avoid redundant WHOIS lookups with built-in caching
-- **Date Filtering** - Focus on recently registered domains
-- **Multiple Formats** - Export to Excel, JSON, CSV, and HTML
+
+- **Comprehensive detection** via [dnstwist](https://github.com/elceef/dnstwist),
+  with registrable-domain splitting from the Public Suffix List so
+  `example.com.br` and `example.github.io` are handled correctly.
+- **RDAP with WHOIS fallback.** RDAP is HTTPS on 443, so registration data
+  still resolves in environments where outbound TCP/43 is blocked — which is
+  most corporate networks.
+- **Async and parallel** scanning with configurable worker pools, and a WHOIS
+  circuit breaker so one unresponsive registrar cannot stall a run.
+- **Smart caching** to avoid redundant lookups.
+- **Change detection.** Alerts fire on what *moved* since the last scan, never
+  on the full result set. A daily scan that re-reported the same seventy
+  lookalikes every morning gets ignored within a week.
 
 ### Enhanced Detection Methods (Optional)
+
 > ![Enhance!](https://media1.tenor.com/m/vp7s5OGK-RUAAAAd/enhance.gif)
 >
 > *"ENHANCE!" — Just like in the movies, but with more DNS lookups. Use enhanced detection with caution!*
-- **Combo-Squatting** - Detects domains combining your brand with popular keywords (e.g., `example-shop.com`, `secure-example.com`)
-  - 50+ keywords: login, secure, account, shop, store, support, admin, payment, verify, etc.
-  - Multiple separators: hyphens, underscores, numbers
-  - Configurable via `enable_combosquatting` setting
 
-- **Sound-Alike Detection** - Finds domains that sound phonetically similar using Soundex and Metaphone algorithms
-  - Example: `example.com` → `exampul.com`, `egzample.com`
-  - Configurable via `enable_soundalike` setting
+- **Combo-squatting** — brand plus a keyword (`example-shop.com`,
+  `secure-example.com`). 50+ defaults, and `custom_keywords` for your own
+  product, campaign, and portal names, which make far better bait than the
+  generic list. `enable_combosquatting`
+- **Sound-alike** — Soundex and Metaphone (`exampul.com`, `egzample.com`).
+  `enable_soundalike`
+- **IDN homographs** — confusable Unicode (`еxample.com` with a Cyrillic е).
+  `enable_idn_homograph`
 
-- **IDN Homograph Detection** - Identifies internationalized domain names using confusable Unicode characters
-  - Example: `example.com` → `еxample.com` (Cyrillic 'е'), `exаmple.com` (Cyrillic 'а')
-  - Detects mixed-script attacks using lookalike characters
-  - Configurable via `enable_idn_homograph` setting
+### Signals That Indicate Intent
+
+These are the ones worth acting on, because each represents deliberate work by
+the operator rather than the £8 it costs to register a name.
+
+- **Mail capability (SPF / DKIM / DMARC).** Registering a lookalike is cheap.
+  Provisioning it to send mail that passes receiver checks is deliberate work
+  whose only purpose is deliverable mail — the prerequisite for credential
+  phishing and business email compromise. Classified `none` / `receive-only` /
+  `partial` / `provisioned` / `hardened`, and a domain that *gains* send
+  capability between scans raises an escalation.
+- **Credential forms.** A password field paired with a username or email field
+  is the phishing kit itself. A form submitting to a different registrable
+  domain is an exfiltration path, not a login page.
+- **TLS validity.** A valid certificate on a lookalike means someone did the
+  work. Certificates are always validated — a validation failure is recorded as
+  a finding, not worked around.
+- **Registration age.** Log-scaled, because 3 days versus 30 matters far more
+  than 1000 versus 1027.
 
 ### Threat Intelligence Integration (Optional)
-- **URLScan.io** - Analyze live website behavior and security posture
-  - **Auto-enables when API key is configured** (no additional flags needed!)
-  - Requires API key (free tier available at [urlscan.io](https://urlscan.io))
-  - Smart scanning: checks for existing scans first, only submits new scan if older than `urlscan_max_age_days` (default: 7 days)
-  - Waits up to `urlscan_wait_timeout` seconds (default: 90s) for scan results
-  - Provides verdict: malicious, suspicious, clean with threat scores and categories
-  - Returns screenshot URL and report URL for further investigation
-  - Can be explicitly disabled with `ENABLE_URLSCAN=false` environment variable if needed
-  - Configurable via `urlscan_api_key`, `urlscan_max_age_days`, `urlscan_wait_timeout`, and `urlscan_visibility`
 
-- **Certificate Transparency Logs** - Monitor SSL/TLS certificate issuance
-  - Tracks certificate history for domains
-  - No API key required
-  - Configurable via `enable_certificate_transparency`
+- **URLScan.io** — live behaviour and verdicts. Auto-enables when an API key is
+  configured. Checks for an existing scan before submitting a new one.
+  `urlscan_api_key`, `urlscan_max_age_days`, `urlscan_wait_timeout`
+- **Certificate Transparency** — certificate issuance history. No API key.
+  `enable_certificate_transparency`
+- **HTTP probing** — whether the domain serves content, and what that content
+  is built to collect. `enable_http_probe`, `enable_page_analysis`
+- **Risk scoring** — deterministic 0–100 from all of the above. Colour-coded in
+  Excel. `enable_risk_scoring`
 
-- **HTTP Probing** - Test if domains are actively hosting content
-  - Checks HTTP/HTTPS status codes
-  - Configurable timeout (default: 10s)
-  - Configurable via `enable_http_probe` and `http_timeout`
+### Two Rules Worth Knowing
 
-- **Risk Scoring** - Automated threat assessment (0-100 scale)
-  - Combines threat intelligence signals
-  - Color-coded in Excel reports (Red: 70+, Orange: 50-69, Yellow: 30-49)
-  - Configurable via `enable_risk_scoring`
+Both the AI and ML layers follow the same rule, for the same reason:
 
-### Key Features
-- Complete with modern Python async/await
-- Modular, object-oriented architecture
-- Beautiful CLI with progress bars and colored output
-- Enhanced Excel reports with multiple sheets and rich formatting
-- Stunning HTML reports with responsive design
-- YAML-based configuration system
-- Intelligent retry logic and error handling
-- Comprehensive logging with Rich integration
-- Significant performance improvements
+> **They explain and rank. They never score.**
+
+Risk scores are computed deterministically and are identical with both layers
+disabled. A takedown request to a registrar has to rest on evidence anyone can
+reproduce — *"registered nine days ago, valid SPF and DKIM, serving a login
+page"* is an argument a registrar can check. *"Our model put it first"* is not.
+
+> **A failed lookup is never reported as a finding.**
+
+A DNS query that times out yields `unknown`, which scores zero and is labelled
+"Lookup failed" rather than "no SPF". A page that breaks the parser is marked
+truncated rather than passed off as a clean reading. Absence of evidence is not
+evidence of absence, and a tool that blurs the two teaches you to distrust it.
 
 **[⬆ Back to Top](#-table-of-contents)**
 
@@ -364,19 +445,55 @@ typo-sniper [OPTIONS]
 
 ### Options
 
+**Scanning**
+
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-i, --input FILE` | Input file with domains to monitor | `monitored_domains.txt` |
 | `-o, --output DIR` | Output directory for results | `results/` |
-| `--format FORMAT [FORMAT ...]` | Output formats (excel, json, csv, html) | `excel` |
-| `--months N` | Filter domains registered in last N months (0 = no filter) | `0` |
-| `--config FILE` | Path to YAML configuration file | None |
+| `--format FORMAT [...]` | Output formats: excel, json, csv, html | `excel` |
+| `--months N` | Only domains registered in the last N months (0 = no filter) | `0` |
+| `--config FILE` | Path to a YAML configuration file | None |
 | `--max-workers N` | Maximum concurrent workers | `10` |
-| `--cache-ttl SECONDS` | Cache TTL in seconds | `86400` (24h) |
-| `--no-cache` | Disable caching | False |
-| `-v, --verbose` | Enable verbose output (INFO level) | False |
-| `--debug` | Enable debug output (DEBUG level with tracing) | False |
-| `--version` | Show version and exit | - |
+| `--cache-ttl SECONDS` | Cache TTL | `86400` |
+| `--no-cache` | Disable caching | off |
+| `--no-rdap` | Skip RDAP, use WHOIS only | off |
+
+**Monitoring and alerting**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--watch` | Run continuously, rescanning on an interval | off |
+| `--interval SPEC` | Interval in watch mode, e.g. `6h`, `30m` | `24h` |
+| `--no-diff` | Disable change detection against previous scans | off |
+| `--notify CHANNEL [...]` | slack, discord, teams, matrix, jira, webhook, email | none |
+| `--notify-min-changes N` | Only alert at or above this many changes | `1` |
+
+**AI triage** — see [AI Analysis](docs/guides/AI_ANALYSIS.md)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ai` | Enable AI-assisted triage (explains, never scores) | off |
+| `--ai-provider NAME` | claude, openai, gemini, ollama | `claude` |
+| `--ai-model NAME` | Model for the chosen provider | provider default |
+
+**Learned ranking** — see [ML Triage](docs/guides/ML_TRIAGE.md)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--label DOMAIN=acted\|dismissed` | Record a triage decision, then exit | — |
+| `--ml-status` | Report label counts and the trained model, then exit | — |
+| `--ml-train` | Train the ranking model on labelled history, then exit | — |
+| `--ml-rank` | Order findings by the trained model | off |
+
+**Diagnostics**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--secrets-check` | Report reachable secrets backends and where each credential resolved from. Never prints a value. | — |
+| `-v, --verbose` | Verbose output (INFO) | off |
+| `--debug` | Debug output with tracing | off |
+| `--version` | Show version and exit | — |
 
 ### Examples
 
@@ -434,7 +551,7 @@ typo-sniper -v
 typo-sniper --debug
 ```
 
-> 💡 **Tip:** Use `--debug` to troubleshoot issues like "why am I getting 0 enhanced detections?" It will show you which features are enabled/disabled. See [DEBUG_MODE.md](DEBUG_MODE.md) for details.
+> 💡 **Tip:** Use `--debug` to troubleshoot issues like "why am I getting 0 enhanced detections?" It will show you which features are enabled/disabled. See [DEBUG_MODE.md](docs/guides/DEBUG_MODE.md) for details.
 
 **[⬆ Back to Top](#-table-of-contents)**
 
@@ -1535,7 +1652,7 @@ doppler configs tokens create prod-token --plain
 - **AWS Secrets Manager Guide:** https://docs.aws.amazon.com/secretsmanager/
 - **Environment Variables Best Practices:** https://12factor.net/config
 - **Typo Sniper Testing Guide:** [TESTING.md](TESTING.md)
-- **Typo Sniper Quick Start:** [QUICKSTART.md](QUICKSTART.md)
+- **Typo Sniper Quick Start:** [QUICKSTART.md](docs/guides/QUICKSTART.md)
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,12 +6,18 @@ This guide covers how to test Typo Sniper's threat intelligence integrations wit
 
 1. [Getting API Keys](#getting-api-keys)
 2. [Testing with URLScan.io](#testing-with-urlscanio)
-4. [Secrets Management Options](#secrets-management-options)
+3. [Full Threat Intelligence Configuration](#full-threat-intelligence-configuration)
+4. Secrets management
    - [Using Doppler](#using-doppler-secrets-manager)
    - [Using AWS Secrets Manager](#using-aws-secrets-manager)
    - [Using Environment Variables](#using-environment-variables)
 5. [Testing with Docker](#testing-with-docker)
 6. [Troubleshooting](#troubleshooting)
+7. [Example Test Workflow](#example-test-workflow)
+
+> This page covers the manual, API-key-dependent checks. For the automated
+> suite see [tests/README.md](tests/README.md), and for what has and has not
+> been verified against real services see [docs/STATUS.md](docs/STATUS.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Comprehensive documentation for Typo Sniper.
 - **[README.md](../README.md)** - Main project documentation
 - **[QUICKSTART.md](guides/QUICKSTART.md)** - Get up and running in 5 minutes
 - **[TESTING.md](../TESTING.md)** - Testing guide
+- **[STATUS.md](STATUS.md)** - 🧪 What is verified, what needs your testing, what to report
 
 ### Guides
 - **[API_KEYS_SETUP.md](guides/API_KEYS_SETUP.md)** - Setting up URLScan.io API keys
@@ -28,6 +29,7 @@ Comprehensive documentation for Typo Sniper.
 ```
 docs/
 ├── README.md                           # This file
+├── STATUS.md                           # Feature status and help wanted
 ├── config.yaml.example                 # Example configuration
 └── guides/                             # User guides
     ├── API_KEYS_SETUP.md              # API key setup

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,151 @@
+# Feature Status: What's Verified, What Needs Your Testing
+
+Typo Sniper gained a lot of surface area quickly. This page is an honest
+account of what has been exercised against real services and what has only ever
+run against tests and stubs.
+
+**Nothing here is known-broken.** Every feature has automated tests, and the
+suite is hermetic — a fixture fails any test that opens a socket to anything but
+localhost. But a passing stub test proves the code does what its author
+expected, not that a vendor's API agrees. The gap between those two is where
+this list lives, and closing it needs people with real accounts and real
+domains.
+
+If you try something below, **please open an issue either way** — "this worked
+exactly as documented" is as useful a data point as a bug report, and much
+rarer.
+
+---
+
+## Fully verified
+
+Exercised end to end, against real data, with no external account required.
+
+| Feature | Since | How it was verified |
+|---|---|---|
+| dnstwist detection, combo-squat, sound-alike, IDN | 1.0 | Unit tests, real scans |
+| Public Suffix List domain splitting | 1.3.0 | Unit tests over multi-label suffixes |
+| DNS resolution, mail posture (SPF/DKIM/DMARC) | 1.3.0 | Real DNS, including TCP retry for large TXT |
+| Change detection and diffing | 1.2.0 | Round-trip tests over recorded history |
+| Risk scoring | 1.1.0 | Unit tests per signal and combination |
+| Page analysis / credential forms | 2.1.0 | Fixture HTML, incl. malformed and hostile input |
+| Report exports (Excel, JSON, CSV, HTML) | 1.0 | Generated and opened |
+| Packaging: build, install, console script | 2.0.0 | Built and installed into clean 3.10 / 3.11 venvs |
+| Prompt-injection defences | 1.4.0 | Adversarial fixtures; 0 markers escaped |
+
+---
+
+## Needs testing against real services
+
+These have complete implementations and passing tests, but **no request has
+ever left a developer's machine to the real endpoint.** Request shapes are
+asserted against stubs built from vendor documentation.
+
+### 🔑 Secrets backends — [issue #5](https://github.com/ChiefGyk3D/typo-sniper/issues/5)
+
+| Backend | Status | What would help |
+|---|---|---|
+| Environment / `.env` | ✅ Verified | — |
+| Doppler | ⚠️ Untested live | Does `doppler run` injection resolve? Does the REST path work with a service token? |
+| AWS Secrets Manager | ⚠️ Untested live | Does the JSON-blob secret parse? Does an instance profile / IRSA resolve? |
+| HashiCorp Vault | ⚠️ Untested live | KV v2 path shape, namespace header, `~/.vault-token` pickup |
+| Azure Key Vault | ⚠️ Untested live | Does `DefaultAzureCredential` resolve? Is the dashed name mapping right? |
+| GCP Secret Manager | ⚠️ Untested live | Does ADC resolve? Underscore vs dashed secret naming |
+| 1Password | ⚠️ Untested live | Does `op read` work for both a signed-in user and a service account? |
+
+Start with `typo-sniper --secrets-check`. It reports which backends are
+reachable and where each credential resolved from, and **never prints a value**.
+
+### 🤖 AI providers
+
+No live call has been made to any provider. The request shapes follow current
+API documentation, but APIs drift.
+
+- **Claude** — adaptive thinking, streaming, JSON schema output
+- **OpenAI** — strict JSON schema mode
+- **Gemini** — schema adaptation (it rejects `additionalProperties`)
+- **Ollama** — local HTTP, format-constrained
+
+Most useful report: run `--ai` against a small domain list and say whether the
+response parsed, whether the assessment was *useful*, and roughly what it cost.
+
+### 🔔 Alert channels
+
+| Channel | Status |
+|---|---|
+| Slack, Discord | ⚠️ Payload shapes tested, never delivered live |
+| Microsoft Teams | ⚠️ Untested. Uses Power Automate — the old O365 connector is retired |
+| Matrix | ⚠️ Untested. Check the message renders and the token stays out of logs |
+| **Jira** | ⚠️ **Untested, and the highest-risk one** |
+| Webhook, email | ⚠️ Untested live |
+
+**Test Jira against a scratch project first.** It creates state: one issue per
+domain, deduplicated by label, capped at `jira_max_issues_per_run` (default 10).
+The dedupe logic and the cap are both tested, but a wrong JQL or field shape
+against a real instance is worth finding on a throwaway project rather than your
+security backlog.
+
+### 🧠 Learned triage ranking
+
+**This one cannot be evaluated at all yet, by anyone, including us.**
+
+The plumbing is verified: feature extraction, the training pipeline, the JSON
+model format, the refusal of stale models. But whether the model *helps* is
+unknowable until it has real labels from real triage decisions.
+
+To generate the first real signal:
+
+```bash
+typo-sniper --label suspicious-domain.com=acted
+typo-sniper --label harmless-domain.com=dismissed
+# ...roughly 30 decisions, at least 8 of each
+typo-sniper -i domains.txt --ml-train
+typo-sniper -i domains.txt --ml-status
+```
+
+An unremarkable ROC AUC around 0.5–0.6 **is a legitimate result**, not a bug: it
+means your decisions already track the deterministic risk score and the model
+has nothing to add. That finding is worth reporting.
+
+### ☁️ Infrastructure (Terraform / OpenTofu)
+
+Syntax and formatting are checked. **No `plan` or `apply` has ever run**, because
+the provider registry is unreachable from the development sandbox — so provider
+schemas were never validated and argument names were written from documentation.
+
+Expect to hit at least one argument mismatch on first `tofu plan`. Please report
+them; they are cheap to fix and impossible to find without an AWS account.
+
+The design decision most worth a second opinion: **scan state lives on EFS.**
+Typo Sniper keeps history in a local directory, so a scheduled container on
+ephemeral storage would treat every run as a first run and never report a
+change — working perfectly while doing none of the job. EFS is the fix for both
+ECS and EKS. If you see a better shape, say so.
+
+### 📦 Publishing
+
+The build and install path is verified. The **upload** steps have never run:
+PyPI Trusted Publishing needs a one-time publisher registration, and the GHCR
+push happens only on a `v*` tag.
+
+---
+
+## Known limitations
+
+- **No remote state backend.** Scan history is a local directory. Containerised
+  deployments need a persistent volume (the Terraform modules mount EFS). An
+  S3-backed state store would be a genuine improvement.
+- **Page analysis reads only the first `http_max_bytes`** (1 MiB default). A
+  credential form past that point is not seen.
+- **Brand mention counting is substring-based**, so a short brand name inside a
+  longer unrelated word will match.
+- **The AI layer sends scan metadata to a third party** unless you use Ollama.
+  That metadata names the domains you are defending.
+
+---
+
+## How to report
+
+- **Bugs and live-service results** — [open an issue](https://github.com/ChiefGyk3D/typo-sniper/issues)
+- **Something worked as documented** — say so on the relevant issue; confirmation is genuinely valuable
+- **Security findings** — open an issue without exploit detail and it will be moved somewhere private to continue

--- a/docs/guides/DEBUG_MODE.md
+++ b/docs/guides/DEBUG_MODE.md
@@ -172,6 +172,6 @@ This script demonstrates:
 
 ## See Also
 
-- [TESTING.md](TESTING.md) - Testing documentation
-- [THREAT_INTEL_TESTING.md](THREAT_INTEL_TESTING.md) - Threat intelligence testing
+- [TESTING.md](../../TESTING.md) - Testing documentation
+- [THREAT_INTEL_TESTING.md](../../tests/docs/THREAT_INTEL_TESTING.md) - Threat intelligence testing
 - [QUICKSTART.md](QUICKSTART.md) - Quick start guide

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -92,7 +92,7 @@ aws secretsmanager create-secret \
 export AWS_SECRET_NAME="typo-sniper/prod"
 ```
 
-**See [TESTING.md](TESTING.md) for complete setup guides for each option.**
+**See [TESTING.md](../../TESTING.md) for complete setup guides for each option.**
 
 ## 3. Run Your First Test (1 minute)
 

--- a/src/typo_sniper/version.py
+++ b/src/typo_sniper/version.py
@@ -4,4 +4,4 @@
 # Copyright (C) 2026 ChiefGyk3D
 # Typo Sniper is dual-licensed; see COMMERCIAL.md for commercial terms.
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"


### PR DESCRIPTION
The README's feature list described the tool as of **1.1.0**. Twelve features landed behind it without it changing.

---

## The more useful half: `docs/STATUS.md`

An honest account of what has been verified against real services and what has only ever run against tests and stubs.

Every feature has tests, and the suite is hermetic — a fixture fails any test that opens a socket to anything but localhost. But **a passing stub test proves the code does what its author expected, not that a vendor's API agrees.** Several integrations have never had a request leave a developer's machine:

| Never exercised live | Why it matters |
|---|---|
| Doppler, AWS, Vault, Azure, GCP, 1Password | Six of seven secrets backends |
| Claude, OpenAI, Gemini, Ollama | Every AI provider; request shapes from docs, and APIs drift |
| Teams, Matrix, **Jira** | Jira especially — it's the one channel that creates state |
| Terraform modules | Syntax-checked only; no `plan` ever ran |
| PyPI / GHCR upload | Build and install verified; the upload steps never ran |

And one thing **nobody can evaluate yet, including me**: the learned ranking model has no real labels. It can't be judged until someone makes ~30 real triage decisions and runs `--ml-status`. An unremarkable ROC AUC around 0.5–0.6 there is a *legitimate result* — it means your decisions already track the deterministic risk score — not a bug.

The page names what to try and what to report. The README now leads with a pointer to it, calling out the two highest-value asks: **AWS Secrets Manager** ([#5](https://github.com/ChiefGyk3D/typo-sniper/issues/5)) and **Jira against a scratch project**.

It also documents four known limitations plainly, including the one worth knowing before deploying: **there is no remote state backend**, so containerised runs need a persistent volume or the diff engine silently never reports a change.

## What was stale

- **Feature list** — omitted change detection, notifications, ticketing, RDAP, mail intelligence, the Public Suffix List, AI triage, learned ranking, page analysis, all seven secrets backends, and every deployment path.
- **CLI options table** — missing **fourteen flags**, including every flag for monitoring, alerting, AI, and learned ranking. Rebuilt from the actual parser and grouped by task.
- **Project structure tree** — still showed the pre-2.0.0 flat layout, and an earlier scripted edit of mine had mangled it. Regenerated from the real repository.
- **Seven broken links** — two pointed at `ENHANCEMENTS.md`, a guide that never existed; four used paths relative to the repo root from inside `docs/guides/`; one anchor in `TESTING.md` pointed at a heading that isn't there.

## What was added

Beyond the status page: a summary table mapping every feature to its guide, a section on **the signals that indicate intent** rather than mere registration (mail capability, credential forms, TLS validity, registration age), and the two rules that govern the whole design:

> **The AI and ML layers explain and rank. They never score.**
> A registrar can check *"registered nine days ago, valid SPF and DKIM, serving a login page."* It cannot check *"our model put it first."*

> **A failed lookup is never reported as a finding.**
> A timed-out DNS query yields `unknown`, not "no SPF". A page that breaks the parser is marked truncated, not clean.

## Verification

- **Link checker across all 22 Markdown files** — every relative link and every internal anchor resolves
- **634 tests pass**, `ruff check src/ tests/` clean
- CLI flag table generated from the live parser rather than transcribed
- Project tree generated from the real directory listing

Docs-only: no source behaviour changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhJ6URbMrxPh3sMKdPftR2)_